### PR TITLE
feat: 홈 섹션 컨테이너 실 API 연동 및 카드 컴포넌트 null 대응

### DIFF
--- a/src/app/api/popups/ending-soon/route.ts
+++ b/src/app/api/popups/ending-soon/route.ts
@@ -1,0 +1,45 @@
+import {
+  createBadRequestResponse,
+  createServerErrorResponse,
+  handleProxyResponse,
+} from '../../shared/route-helpers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/+$/, '');
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 10;
+
+export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const authorization = request.headers.get('Authorization');
+  const { searchParams } = new URL(request.url);
+
+  const rawLimit = searchParams.get('limit') ?? String(MAX_LIMIT);
+  const limit = Number(rawLimit);
+
+  if (!Number.isInteger(limit) || limit < MIN_LIMIT || limit > MAX_LIMIT) {
+    return createBadRequestResponse({
+      limit: `limit는 ${MIN_LIMIT} 이상 ${MAX_LIMIT} 이하여야 합니다.`,
+    });
+  }
+
+  searchParams.set('limit', String(limit));
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/popups/ending-soon?${searchParams}`,
+      {
+        headers: {
+          ...(authorization && { Authorization: authorization }),
+        },
+        cache: 'no-store',
+      }
+    );
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[GET /api/popups/ending-soon]', error);
+    return createServerErrorResponse('서버 내부 오류가 발생했습니다.');
+  }
+}

--- a/src/app/api/popups/magazines/route.ts
+++ b/src/app/api/popups/magazines/route.ts
@@ -1,0 +1,41 @@
+import {
+  createBadRequestResponse,
+  createServerErrorResponse,
+  handleProxyResponse,
+} from '../../shared/route-helpers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/+$/, '');
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 3;
+
+export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+
+  const rawLimit = searchParams.get('limit') ?? String(MAX_LIMIT);
+  const limit = Number(rawLimit);
+
+  if (!Number.isInteger(limit) || limit < MIN_LIMIT || limit > MAX_LIMIT) {
+    return createBadRequestResponse({
+      limit: `limit는 ${MIN_LIMIT} 이상 ${MAX_LIMIT} 이하여야 합니다.`,
+    });
+  }
+
+  searchParams.set('limit', String(limit));
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/popups/magazines?${searchParams}`,
+      {
+        cache: 'no-store',
+      }
+    );
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[GET /api/popups/magazines]', error);
+    return createServerErrorResponse('서버 내부 오류가 발생했습니다.');
+  }
+}

--- a/src/app/api/popups/rankings/route.ts
+++ b/src/app/api/popups/rankings/route.ts
@@ -1,0 +1,28 @@
+import {
+  createServerErrorResponse,
+  handleProxyResponse,
+} from '../../shared/route-helpers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/+$/, '');
+
+export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const authorization = request.headers.get('Authorization');
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/popups/rankings`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authorization && { Authorization: authorization }),
+      },
+      cache: 'no-store',
+    });
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[GET /api/popups/rankings]', error);
+    return createServerErrorResponse('시스템 오류가 발생했습니다.');
+  }
+}

--- a/src/app/api/popups/recommended/route.ts
+++ b/src/app/api/popups/recommended/route.ts
@@ -1,0 +1,27 @@
+import {
+  createServerErrorResponse,
+  handleProxyResponse,
+} from '../../shared/route-helpers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/+$/, '');
+
+export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const authorization = request.headers.get('Authorization');
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/popups/recommended`, {
+      headers: {
+        ...(authorization && { Authorization: authorization }),
+      },
+      cache: 'no-store',
+    });
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[GET /api/popups/recommended]', error);
+    return createServerErrorResponse('시스템 오류가 발생했습니다.');
+  }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Related to #53 

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] 홈 섹션 컨테이너 6종 더미 데이터 제거 후 실 API 호출로 교체
      (`main-banner`, `ranking`, `recommend`, `ending-soon`, `magazine`, `notable`)
      — `useEffect` + `fetch` 기반, 각 섹션별 응답 타입 정의 포함
- [x] `CardOverlay`, `CardThumbnail`의 `thumbnailUrl` optional 처리
      — null/undefined 수신 시 `/images/temp/no-image.png` fallback 적용

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 백엔드 API 준비 완료에 따라 홈 화면 전 섹션의 더미 데이터 의존성 제거
- 실 데이터에서 `thumbnailUrl: null`이 내려오는 케이스 대응으로 런타임 오류 방지

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [x] 홈 화면 6개 섹션 실 데이터 렌더링 정상 확인
- [x] 로딩 중 / 빈 데이터 상태 렌더링 오류 없음 확인

## 📷 스크린샷 (선택)

N/A

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

N/A