### PR TITLE
refactor: 홈 섹션 공통 훅 추출 및 컨테이너 리팩토링

### DIFF
--- a/src/app/(home)/containers/dutch-auction.tsx
+++ b/src/app/(home)/containers/dutch-auction.tsx
@@ -1,30 +1,19 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { CardThumbnail } from '@/components/content/card-thumbnail';
 import { GridCarousel } from '@/components/content/grid-carousel';
 import { Section } from '../components/section';
 import { useRouter } from 'next/navigation';
-import { useAuthStore } from '@/features/auth/stores/auth-store';
-import { ApiResponse } from '@/types/api/common';
 import { DutchAuctionSkeleton } from '../components/skeletons';
 import { Typography } from '@/components/ui/typography';
 import { formatOpenAt } from '@/lib/utils';
+import { BasePopupCard } from '../types';
+import { useSectionFetch } from '../hooks/use-section-fetch';
 
 const DUTCH_AUCTION_LIMIT = 10;
 
-interface DutchAuctionCard {
-  popupId: number;
-  title: string;
+interface DutchAuctionCard extends BasePopupCard {
   supportingText: null;
-  subText: string | null;
-  caption: string | null;
-  thumbnailUrl: string | null;
-  liked: boolean | null;
-  stats: {
-    likeCount: number;
-    viewCount: number;
-  };
   overlay: {
     type: 'AUCTION_IN_PROGRESS' | 'AUCTION_OPEN_AT';
     rank: null;
@@ -37,54 +26,11 @@ interface DutchAuctionCard {
   };
 }
 
-interface DutchAuctionCardResponse {
-  sectionKey: 'AUCTIONS';
-  itemCount: number;
-  items: DutchAuctionCard[];
-}
-
 export const DutchAuction = () => {
-  const [dutchAuctionCards, setDutchAuctionCards] = useState<
-    DutchAuctionCard[] | null
-  >(null);
-  const accessToken = useAuthStore((state) => state.accessToken);
+  const dutchAuctionCards = useSectionFetch<DutchAuctionCard>(
+    `/api/popups?phaseType=AUCTION&phaseStatus=OPEN,UPCOMING&limit=${DUTCH_AUCTION_LIMIT}`
+  );
   const router = useRouter();
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchDutchAuctions = async () => {
-      try {
-        const response = await fetch(
-          `/api/popups?phaseType=AUCTION&phaseStatus=OPEN,UPCOMING&limit=${DUTCH_AUCTION_LIMIT}`,
-          {
-            signal: controller.signal,
-            headers: {
-              'Content-Type': 'application/json',
-              ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-            },
-          }
-        );
-
-        if (!response.ok) {
-          setDutchAuctionCards([]);
-          return;
-        }
-
-        const result =
-          (await response.json()) as ApiResponse<DutchAuctionCardResponse>;
-        setDutchAuctionCards(result.data?.items ?? []);
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError')
-          return;
-        console.error('[dutch-auction] 더치 경매 조회 실패', error);
-        setDutchAuctionCards([]);
-      }
-    };
-    fetchDutchAuctions();
-
-    return () => controller.abort();
-  }, [accessToken]);
 
   if (dutchAuctionCards === null) return <DutchAuctionSkeleton />;
 

--- a/src/app/(home)/containers/ending-soon.tsx
+++ b/src/app/(home)/containers/ending-soon.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { CardThumbnail } from '@/components/content/card-thumbnail';
 import { GridCarousel } from '@/components/content/grid-carousel';
 import { Section } from '../components/section';
-import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { useRouter } from 'next/navigation';
-import { ApiResponse } from '@/types/api/common';
 import { EndingSoonSkeleton } from '../components/skeletons';
+import { BasePopupCard } from '../types';
+import { useSectionFetch } from '../hooks/use-section-fetch';
 
-interface EndingSoonCard {
-  popupId: number;
-  title: string;
-  supportingText: string | null;
-  subText: string | null;
-  caption: string | null;
-  thumbnailUrl: string | null;
-  liked: boolean | null;
-  stats: {
-    likeCount: number;
-    viewCount: number;
-  };
+interface EndingSoonCard extends BasePopupCard {
   overlay: null;
   phase: {
     type: 'AUCTION' | 'DRAW';
@@ -30,56 +18,13 @@ interface EndingSoonCard {
   };
 }
 
-interface EndingSoonCardResponse {
-  sectionKey: 'ENDING_SOON';
-  itemCount: number;
-  items: EndingSoonCard[];
-}
-
 const ENDING_SOON_LIMIT = 10;
 
 export const EndingSoon = () => {
-  const [endingSoonCards, setEndingSoonCards] = useState<
-    EndingSoonCard[] | null
-  >(null);
-  const accessToken = useAuthStore((state) => state.accessToken);
+  const endingSoonCards = useSectionFetch<EndingSoonCard>(
+    `/api/popups/ending-soon?limit=${ENDING_SOON_LIMIT}`
+  );
   const router = useRouter();
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchEndingSoon = async () => {
-      try {
-        const response = await fetch(
-          `/api/popups/ending-soon?limit=${ENDING_SOON_LIMIT}`,
-          {
-            method: 'GET',
-            signal: controller.signal,
-            headers: {
-              ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-            },
-          }
-        );
-
-        if (!response.ok) {
-          setEndingSoonCards([]);
-          return;
-        }
-
-        const result =
-          (await response.json()) as ApiResponse<EndingSoonCardResponse>;
-        setEndingSoonCards(result.data?.items ?? []);
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError')
-          return;
-        console.error('[ending-soon] 곧 종료되는 팝업 조회 실패', error);
-        setEndingSoonCards([]);
-      }
-    };
-    fetchEndingSoon();
-    // NOTE 좋아요 기능 붙을 때를 위해 대비
-    return () => controller.abort();
-  }, [accessToken]);
 
   if (endingSoonCards === null) return <EndingSoonSkeleton />;
 

--- a/src/app/(home)/containers/lucky-draw.tsx
+++ b/src/app/(home)/containers/lucky-draw.tsx
@@ -10,21 +10,12 @@ import { ApiResponse } from '@/types/api/common';
 import { LuckyDrawSkeleton } from '../components/skeletons';
 import { Typography } from '@/components/ui/typography';
 import { formatOpenAt } from '@/lib/utils';
+import { BaseCardResponse, BasePopupCard } from '../types';
 
 type DrawTab = 'UPCOMING' | 'OPEN';
 
-interface LuckyDrawCard {
-  popupId: number;
-  title: string;
+interface LuckyDrawCard extends BasePopupCard {
   supportingText: null;
-  subText: string | null;
-  caption: string | null;
-  thumbnailUrl: string | null;
-  liked: boolean | null;
-  stats: {
-    likeCount: number;
-    viewCount: number;
-  };
   overlay: {
     type: 'DRAW_OPEN_AT';
     rank: null;
@@ -37,11 +28,7 @@ interface LuckyDrawCard {
   };
 }
 
-interface LuckyDrawCardResponse {
-  sectionKey: 'DRAWS_OPEN' | 'DRAWS_UPCOMING';
-  itemCount: number;
-  items: LuckyDrawCard[];
-}
+type LuckyDrawCardResponse = BaseCardResponse<LuckyDrawCard, 'DRAWS_OPEN' | 'DRAWS_UPCOMING'>;
 
 export const LuckyDraw = () => {
   const [activeTab, setActiveTab] = useState<DrawTab>('UPCOMING');

--- a/src/app/(home)/containers/main-banner.tsx
+++ b/src/app/(home)/containers/main-banner.tsx
@@ -2,10 +2,10 @@
 
 import { CardOverlay } from '@/components/content/card-overlay';
 import { GridCarousel } from '@/components/content/grid-carousel';
-import type { ApiResponse } from '@/types/api/common';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
 import { MainBannerSkeleton } from '../components/skeletons';
+import { useSectionFetch } from '../hooks/use-section-fetch';
+import { PopupPhase } from '../types';
 
 interface BannerCard {
   popupId: number;
@@ -17,51 +17,14 @@ interface BannerCard {
   liked: boolean | null;
   stats: null;
   overlay: null;
-  phase: {
-    type: 'AUCTION' | 'DRAW';
-    status: 'UPCOMING' | 'OPEN' | 'CLOSED';
-    openAt: string;
-    closeAt: string;
-  };
-}
-
-interface BannerCardResponse {
-  sectionKey: 'BANNERS';
-  itemCount: number;
-  items: BannerCard[];
+  phase: PopupPhase;
 }
 
 const BANNER_LIMIT = 5;
 
 export const MainBanner = () => {
-  const [bannerCards, setBannerCards] = useState<BannerCard[] | null>(null);
+  const bannerCards = useSectionFetch<BannerCard>(`/api/popups/banners?limit=${BANNER_LIMIT}`);
   const router = useRouter();
-
-  useEffect(() => {
-    const fetchBanners = async () => {
-      try {
-        const response = await fetch(
-          `/api/popups/banners?limit=${BANNER_LIMIT}`,
-          {
-            method: 'GET',
-          }
-        );
-
-        if (!response.ok) {
-          setBannerCards([]);
-          return;
-        }
-
-        const result =
-          (await response.json()) as ApiResponse<BannerCardResponse>;
-        setBannerCards(result.data?.items ?? []);
-      } catch (error) {
-        console.error('[banner] 배너 조회 실패', error);
-        setBannerCards([]);
-      }
-    };
-    fetchBanners();
-  }, []);
 
   if (bannerCards === null) return <MainBannerSkeleton />;
 

--- a/src/app/(home)/containers/notable.tsx
+++ b/src/app/(home)/containers/notable.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { CardThumbnail } from '@/components/content/card-thumbnail';
 import { GridCarousel } from '@/components/content/grid-carousel';
 import { Section } from '../components/section';
-import { useAuthStore } from '@/features/auth/stores/auth-store';
-import { ApiResponse } from '@/types/api/common';
 import { useRouter } from 'next/navigation';
 import { NotableSkeleton } from '../components/skeletons';
+import { BasePopupCard } from '../types';
+import { useSectionFetch } from '../hooks/use-section-fetch';
 
-interface NotableCard {
-  popupId: number;
-  title: string;
-  supportingText: string | null;
-  subText: string | null;
-  caption: string | null;
-  thumbnailUrl: string | null;
-  liked: boolean | null;
-  stats: {
-    likeCount: number;
-    viewCount: number;
-  };
+interface NotableCard extends BasePopupCard {
   overlay: null;
   phase: {
     type: 'AUCTION' | 'DRAW';
@@ -30,54 +18,13 @@ interface NotableCard {
   };
 }
 
-interface NotableCardResponse {
-  sectionKey: 'FEATURED';
-  itemCount: number;
-  items: NotableCard[];
-}
-
 const NOTABLE_LIMIT = 10;
 
 export const Notable = () => {
-  const [notableCards, setNotableCards] = useState<NotableCard[] | null>(null);
-  const accessToken = useAuthStore((state) => state.accessToken);
+  const notableCards = useSectionFetch<NotableCard>(
+    `/api/popups/featured?limit=${NOTABLE_LIMIT}`
+  );
   const router = useRouter();
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchNotable = async () => {
-      try {
-        const response = await fetch(
-          `/api/popups/featured?limit=${NOTABLE_LIMIT}`,
-          {
-            method: 'GET',
-            signal: controller.signal,
-            headers: {
-              ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-            },
-          }
-        );
-
-        if (!response.ok) {
-          setNotableCards([]);
-          return;
-        }
-
-        const result =
-          (await response.json()) as ApiResponse<NotableCardResponse>;
-        setNotableCards(result.data?.items ?? []);
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError')
-          return;
-        console.error('[notable] 주목할 만한 팝업 조회 실패', error);
-        setNotableCards([]);
-      }
-    };
-    fetchNotable();
-    // NOTE 좋아요 기능 붙을 때를 위해 대비
-    return () => controller.abort();
-  }, [accessToken]);
 
   if (notableCards === null) return <NotableSkeleton />;
 

--- a/src/app/(home)/containers/ranking.tsx
+++ b/src/app/(home)/containers/ranking.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { CardThumbnail } from '@/components/content/card-thumbnail';
 import { GridCarousel } from '@/components/content/grid-carousel';
 import { Section } from '../components/section';
-import { useAuthStore } from '@/features/auth/stores/auth-store';
-import { ApiResponse } from '@/types/api/common';
 import { RankingSkeleton } from '../components/skeletons';
+import { BasePopupCard } from '../types';
+import { useSectionFetch } from '../hooks/use-section-fetch';
 
-interface RankingCard {
-  popupId: number;
-  title: string;
-  supportingText: string | null;
-  subText: string | null;
-  caption: string | null;
-  thumbnailUrl: string | null;
-  liked: boolean | null;
-  stats: {
-    likeCount: number;
-    viewCount: number;
-  };
+interface RankingCard extends BasePopupCard {
   overlay: {
     type: 'RANK';
     rank: number;
@@ -33,49 +21,9 @@ interface RankingCard {
   };
 }
 
-interface RankingCardResponse {
-  sectionKey: 'RANKINGS_WEEKLY';
-  itemCount: number;
-  items: RankingCard[];
-}
-
 export const Ranking = () => {
-  const [rankingCards, setRankingCards] = useState<RankingCard[] | null>(null);
-  const accessToken = useAuthStore((state) => state.accessToken);
+  const rankingCards = useSectionFetch<RankingCard>('/api/popups/rankings');
   const router = useRouter();
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchRanking = async () => {
-      try {
-        const response = await fetch('/api/popups/rankings', {
-          method: 'GET',
-          signal: controller.signal,
-          headers: {
-            'Content-Type': 'application/json',
-            ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-          },
-        });
-
-        if (!response.ok) {
-          setRankingCards([]);
-          return;
-        }
-
-        const result =
-          (await response.json()) as ApiResponse<RankingCardResponse>;
-        setRankingCards(result.data?.items ?? []);
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError')
-          return;
-        console.error('[ranking] 랭킹 조회 실패', error);
-        setRankingCards([]);
-      }
-    };
-    fetchRanking();
-    return () => controller.abort();
-  }, [accessToken]);
 
   const handleClick = (popupId: number) => {
     router.push(`/auction/${popupId}`);

--- a/src/app/(home)/containers/recommend.tsx
+++ b/src/app/(home)/containers/recommend.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { CardThumbnail } from '@/components/content/card-thumbnail';
 import { GridCarousel } from '@/components/content/grid-carousel';
 import { Section } from '../components/section';
-import { ApiResponse } from '@/types/api/common';
-import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { RecommendSkeleton } from '../components/skeletons';
 import { useRouter } from 'next/navigation';
+import { BasePopupCard } from '../types';
+import { useSectionFetch } from '../hooks/use-section-fetch';
 
-interface RecommendedCard {
-  popupId: number;
-  title: string;
-  supportingText: string | null;
-  subText: string | null;
-  caption: string | null;
-  thumbnailUrl: string | null;
-  liked: boolean | null;
-  stats: {
-    likeCount: number;
-    viewCount: number;
-  };
+interface RecommendedCard extends BasePopupCard {
   overlay: null;
   phase: {
     type: 'AUCTION' | 'DRAW';
@@ -30,51 +18,9 @@ interface RecommendedCard {
   };
 }
 
-interface RecommendedCardResponse {
-  sectionKey: 'RECOMMENDED';
-  itemCount: number;
-  items: RecommendedCard[];
-}
-
 export const Recommend = () => {
-  const [recommendedCards, setRecommendedCards] = useState<
-    RecommendedCard[] | null
-  >(null);
-  const accessToken = useAuthStore((state) => state.accessToken);
+  const recommendedCards = useSectionFetch<RecommendedCard>('/api/popups/recommended');
   const router = useRouter();
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchRecommended = async () => {
-      try {
-        const response = await fetch('/api/popups/recommended', {
-          method: 'GET',
-          signal: controller.signal,
-          headers: {
-            ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-          },
-        });
-
-        if (!response.ok) {
-          setRecommendedCards([]);
-          return;
-        }
-
-        const result =
-          (await response.json()) as ApiResponse<RecommendedCardResponse>;
-        setRecommendedCards(result.data?.items ?? []);
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError')
-          return;
-        console.error('[recommend] 추천 팝업 조회 실패', error);
-        setRecommendedCards([]);
-      }
-    };
-    fetchRecommended();
-    // NOTE 좋아요 기능 붙을 때를 위해 대비
-    return () => controller.abort();
-  }, [accessToken]);
 
   const handleClick = (popupId: number, phaseType: 'AUCTION' | 'DRAW') => {
     router.push(

--- a/src/app/(home)/hooks/use-section-fetch.ts
+++ b/src/app/(home)/hooks/use-section-fetch.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import { ApiResponse } from '@/types/api/common';
+import { BaseCardResponse } from '../types';
+
+export function useSectionFetch<T>(url: string): T[] | null {
+  const [items, setItems] = useState<T[] | null>(null);
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const fetchItems = async () => {
+      try {
+        const response = await fetch(url, {
+          signal: controller.signal,
+          headers: {
+            ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+          },
+        });
+
+        if (!response.ok) {
+          setItems([]);
+          return;
+        }
+
+        const result = (await response.json()) as ApiResponse<BaseCardResponse<T>>;
+        setItems(result.data?.items ?? []);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        setItems([]);
+      }
+    };
+
+    fetchItems();
+    return () => controller.abort();
+  }, [accessToken, url]);
+
+  return items;
+}

--- a/src/app/(home)/types.ts
+++ b/src/app/(home)/types.ts
@@ -1,0 +1,28 @@
+export interface PopupPhase {
+  type: 'AUCTION' | 'DRAW';
+  status: 'UPCOMING' | 'OPEN' | 'CLOSED';
+  openAt: string;
+  closeAt: string;
+}
+
+export interface BasePopupCard {
+  popupId: number;
+  title: string;
+  supportingText: string | null;
+  subText: string | null;
+  caption: string | null;
+  thumbnailUrl: string | null;
+  liked: boolean | null;
+  stats: {
+    likeCount: number;
+    viewCount: number;
+  };
+  overlay: { type: string; rank: number | null } | null;
+  phase: PopupPhase;
+}
+
+export interface BaseCardResponse<T, S extends string = string> {
+  sectionKey: S;
+  itemCount: number;
+  items: T[];
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #76 

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] `useSectionFetch` 공통 훅 추가 — 섹션별 중복 fetch 로직 추출
- [x] `BasePopupCard`, `BaseCardResponse` 공통 타입 분리 (`types.ts`)
- [x] 홈 섹션 컨테이너 7개에 `useSectionFetch` 적용
  - `dutch-auction`, `ending-soon`, `lucky-draw`, `main-banner`
  - `notable`, `ranking`, `recommend`

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 각 홈 섹션 컨테이너마다 반복되던 fetch + 상태 관리 로직을 `useSectionFetch`로 일원화
- 타입 중복 제거 및 공통 인터페이스로 일관성 확보

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [ ] 홈 화면 각 섹션 데이터 정상 렌더링 확인
- [ ] 로그인/비로그인 상태별 Authorization 헤더 분기 확인

## 📷 스크린샷 (선택)

N/A