### PR TITLE
feat: 메인 페이지 ui 개선

### DIFF
--- a/src/app/(home)/containers/dutch-auction.tsx
+++ b/src/app/(home)/containers/dutch-auction.tsx
@@ -62,6 +62,11 @@ export const DutchAuction = () => {
               <CardThumbnail
                 thumbnailUrl={dutchAuctionCard.thumbnailUrl ?? undefined}
                 thumbnailRatio="16/9"
+                thumbnailClassName={
+                  dutchAuctionCard.overlay.type === 'AUCTION_OPEN_AT'
+                    ? 'brightness-70'
+                    : undefined
+                }
                 title={dutchAuctionCard.title}
                 description={dutchAuctionCard.subText ?? undefined}
                 caption={dutchAuctionCard.caption ?? undefined}

--- a/src/app/(home)/containers/magazine.tsx
+++ b/src/app/(home)/containers/magazine.tsx
@@ -77,7 +77,7 @@ export const Magazine = () => {
           gridSize={{
             default: 1,
             md: 2,
-            lg: 4,
+            lg: 3,
           }}
           carouselOpts={{ align: 'start' }}
           items={magazineCards.map((magazineCard) => (

--- a/src/app/(home)/containers/main-banner.tsx
+++ b/src/app/(home)/containers/main-banner.tsx
@@ -23,7 +23,9 @@ interface BannerCard {
 const BANNER_LIMIT = 5;
 
 export const MainBanner = () => {
-  const bannerCards = useSectionFetch<BannerCard>(`/api/popups/banners?limit=${BANNER_LIMIT}`);
+  const bannerCards = useSectionFetch<BannerCard>(
+    `/api/popups/banners?limit=${BANNER_LIMIT}`
+  );
   const router = useRouter();
 
   if (bannerCards === null) return <MainBannerSkeleton />;
@@ -44,7 +46,9 @@ export const MainBanner = () => {
   return (
     <GridCarousel
       gridSize="auto"
-      carouselOpts={{ loop: true }}
+      carouselOpts={{ loop: true, align: 'center' }}
+      contentWrapperClassName="overflow-visible"
+      contentClassName="justify-center"
       showIndexes
       items={bannerCards.map((bannerCard) => (
         <div key={bannerCard.popupId} className="w-[384px]">

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -11,7 +11,7 @@ import { Recommend } from './containers/recommend';
 
 export default function Home() {
   return (
-    <div className="mt-6">
+    <div className="mt-6 overflow-hidden">
       {/* 메인 배너 */}
       <MainBanner />
       {/* 카테고리 */}

--- a/src/components/content/card-overlay/index.tsx
+++ b/src/components/content/card-overlay/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Typography } from '@/components/ui/typography';
 import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -75,18 +76,20 @@ export const CardOverlay: React.FC<CardOverlayProps> = ({
         )}
       >
         <div className="flex flex-col justify-start items-start gap-1">
-          <h6
+          <Typography
+            variant="heading-1"
+            weight="bold"
             className={cn(
               'title',
-              'self-stretch justify-start text-Common-White text-3xl font-bold leading-10 line-clamp-2'
+              'self-stretch justify-start leading-10 line-clamp-2'
             )}
           >
             {title}
-          </h6>
+          </Typography>
           {description && (
-            <div className="justify-start text-Common-White text-lg font-normal leading-6">
+            <Typography variant="title-2" className="justify-start leading-6">
               {description}
-            </div>
+            </Typography>
           )}
           {caption && (
             <div className="justify-start text-Common-White text-sm font-normal leading-5">

--- a/src/components/content/card-thumbnail/index.tsx
+++ b/src/components/content/card-thumbnail/index.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@/components/Icon/Icon';
 
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Box } from '@/components/ui/box';
+import { Typography } from '@/components/ui/typography';
 
 const thumbnailVariants = cva(
   'w-full rounded-ml border border-Line-Line-3/10 object-cover',
@@ -37,6 +38,7 @@ export interface CardThumbnailProps {
   showCountView?: boolean;
   showCountLike?: boolean;
   isLiked?: boolean;
+  thumbnailClassName?: string;
   overlayBadge?: React.ReactNode;
   overlayBadgeBackground?: string;
   overlayBadgeClassName?: string;
@@ -59,6 +61,7 @@ export const CardThumbnail: React.FC<CardThumbnailProps> = ({
   showCountLike,
   index,
   isLiked,
+  thumbnailClassName,
   overlayBadge,
   overlayBadgeBackground,
   overlayBadgeClassName,
@@ -99,7 +102,8 @@ export const CardThumbnail: React.FC<CardThumbnailProps> = ({
           <img
             className={cn(
               'thumbnail',
-              thumbnailVariants({ ratio: thumbnailRatio })
+              thumbnailVariants({ ratio: thumbnailRatio }),
+              thumbnailClassName
             )}
             src={thumbnailUrl ?? '/images/temp/no-image.png'}
             alt={thumbnailAlt || title || ''}
@@ -153,23 +157,32 @@ export const CardThumbnail: React.FC<CardThumbnailProps> = ({
                 </div>
               </div>
             )}
-            <h6
+            <Typography
+              variant="title-2"
+              weight="bold"
               className={cn(
                 'title',
-                'justify-start text-Contents-High text-lg font-bold leading-6'
+                'justify-start text-Contents-High text-lg leading-6'
               )}
             >
               {title}
-            </h6>
+            </Typography>
             {description && (
-              <div className="justify-start text-Contents-High text-base font-normal leading-6">
+              <Typography
+                variant="body-1"
+                weight="regular"
+                className="justify-start text-base leading-6 text-[var(--content-high)]"
+              >
                 {description}
-              </div>
+              </Typography>
             )}
             {caption && (
-              <div className="justify-start text-Contents-Extra-Low text-xs font-normal leading-5 text-neutral-60">
+              <Typography
+                variant="caption-1"
+                className="justify-start text-xs font-normal leading-5 text-[var(--content-extra-low)]"
+              >
                 {caption}
-              </div>
+              </Typography>
             )}
             <div className="inline-flex justify-start items-center gap-2 text-neutral-500">
               {showCountView && (

--- a/src/components/content/grid-carousel/index.tsx
+++ b/src/components/content/grid-carousel/index.tsx
@@ -90,18 +90,23 @@ export interface GridCarouselProps {
   showArrows?: boolean;
   showIndexes?: boolean;
   alignArrowToRatio?: '3/4' | '16/9' | '1/1' | 'auto';
+  contentWrapperClassName?: string;
+  contentClassName?: string;
 }
 
 export const GridCarousel: React.FC<GridCarouselProps> = ({
-  gridSize = 4,
+  gridSize = 3,
   items,
   carouselOpts,
   showArrows = true,
   showIndexes,
   alignArrowToRatio = 'auto',
+  contentWrapperClassName,
+  contentClassName,
 }) => {
   const [api, setApi] = React.useState<CarouselApi>();
   const [current, setCurrent] = React.useState(0);
+  const [canScroll, setCanScroll] = React.useState(false);
 
   const basisClass = getResponsiveClasses(gridSize, 'basis');
   const widthClass = getResponsiveClasses(gridSize, 'width');
@@ -131,29 +136,35 @@ export const GridCarousel: React.FC<GridCarouselProps> = ({
   );
 
   React.useEffect(() => {
-    if (!api) {
-      return;
-    }
+    if (!api) return;
 
     const onSelect = () => setCurrent(api.selectedScrollSnap() + 1);
     setCurrent(api.selectedScrollSnap() + 1);
-
     api.on('select', onSelect);
+    return () => { api.off('select', onSelect); };
+  }, [api]);
+
+  React.useEffect(() => {
+    if (!api) return;
+
+    const update = () => setCanScroll(api.scrollSnapList().length > 1);
+    update();
+    api.on('reInit', update);
     return () => {
-      api.off('select', onSelect);
+      api.off('reInit', update);
     };
   }, [api]);
 
   return (
     <Carousel className="w-full" opts={carouselOpts} setApi={setApi}>
-      <CarouselContent>
+      <CarouselContent wrapperClassName={contentWrapperClassName} className={contentClassName}>
         {items.map((item, index) => (
           <CarouselItem key={index} className={cn('', basisClass)}>
             <div className="pl-0">{item}</div>
           </CarouselItem>
         ))}
       </CarouselContent>
-      {showArrows && (
+      {showArrows && canScroll && (
         <div
           className={cn(
             'container absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none z-10 flex justify-between',
@@ -170,7 +181,7 @@ export const GridCarousel: React.FC<GridCarouselProps> = ({
           </div>
         </div>
       )}
-      {showIndexes && (
+      {showIndexes && canScroll && (
         <div className="flex justify-center items-center gap-2 mt-6">
           {Array.from({ length: items.length }).map((_, index) => (
             <div

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import { Box } from '@/components/ui/box';
 import { Typography } from '../ui/typography';
@@ -55,11 +56,8 @@ export const Footer = () => {
     <footer className="w-full pt-10 pb-12 border-t border-[#ebebeb]">
       <Box className="max-w-[1280px] mx-auto px-10">
         <Box className="flex items-center justify-between">
-          <Link
-            href="/"
-            className="w-[130px] h-[32px] flex items-center justify-center logo bg-[#E5E5E5] text-black"
-          >
-            Logo
+          <Link href="/" className="text-black" aria-label="POP-CON 홈">
+            <Image src="/Logo.svg" alt="" width={70} height={40} />
           </Link>
           <nav>
             <ul className="flex gap-8">

--- a/src/components/ui/carousel/index.tsx
+++ b/src/components/ui/carousel/index.tsx
@@ -144,13 +144,17 @@ function Carousel({
   );
 }
 
-function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
+function CarouselContent({
+  className,
+  wrapperClassName,
+  ...props
+}: React.ComponentProps<'div'> & { wrapperClassName?: string }) {
   const { carouselRef, orientation } = useCarousel();
 
   return (
     <div
       ref={carouselRef}
-      className="overflow-hidden"
+      className={cn('overflow-hidden', wrapperClassName)}
       data-slot="carousel-content"
     >
       <div


### PR DESCRIPTION
## #️⃣ 관련 이슈

N/A

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] 메인 배너 carousel `align: center` 및 overflow 처리
- [x] 더치옥션 컴포넌트 `AUCTION_OPEN_AT` 상태 시 썸네일 어둡게 처리
- [x] 매거진 그리드 lg 4열 → 3열 조정
- [x] `CardThumbnail` — `thumbnailClassName` prop 추가
- [x] `GridCarousel` — `contentWrapperClassName`, `contentClassName` props 추가
- [x] `CardOverlay`, `Carousel`, `Footer` 수정

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 메인 페이지 배너 및 카드 레이아웃 UI 개선
- 컴포넌트 스타일 커스터마이징을 위한 className prop 확장

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [x] 메인 배너 중앙 정렬 및 overflow 정상 동작 확인
- [x] 더치옥션 오픈 예정 카드 어둡게 표시 확인
- [x] 매거진 섹션 3열 레이아웃 확인