### PR TITLE
feat: 대기열 폴링 간격 서버 응답값 적용

### DIFF
--- a/src/features/queue/hooks/use-queue.ts
+++ b/src/features/queue/hooks/use-queue.ts
@@ -26,7 +26,7 @@ export function useQueue({ queueToken, onActive }: UseQueueOptions) {
     },
     refetchInterval: (query) => {
       if (query.state.data?.data?.status === 'ACTIVE') return false;
-      return query.state.data?.data?.pollAfterMs ?? 3000;
+      return Math.max(query.state.data?.data?.pollAfterMs ?? 3000, 1000);
     },
     enabled: !!queueToken,
     retry: false,


### PR DESCRIPTION
## #️⃣ 관련 이슈

N/A

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] 대기열 폴링 간격을 고정값(3000ms)에서 서버 응답의 `pollAfterMs` 값으로 변경

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 서버가 내려주는 `pollAfterMs`를 실제 폴링 간격에 반영 (응답값 없으면 기본 3초)

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- 실제 QA때 테스트 필요