### PR TITLE
fix: 로그인 후 클라이언트 인증 상태 초기화 방지

### DIFF
--- a/src/components/auth/conditional-auth-session-restore.tsx
+++ b/src/components/auth/conditional-auth-session-restore.tsx
@@ -21,11 +21,13 @@ export default function ConditionalAuthSessionRestore({
   isLoggedIn: boolean;
 }) {
   const pathname = usePathname();
+  const authStatus = useAuthStore((state) => state.authStatus);
 
   const isAuthPage = AUTH_PATHS.some((path) => pathname.startsWith(path));
 
   if (isAuthPage) return null;
-  if (!isLoggedIn) return <SetUnauthenticated />;
+  if (!isLoggedIn && authStatus !== 'authenticated')
+    return <SetUnauthenticated />;
 
   return <AuthSessionRestore />;
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Related to #114 

## 📝 작업 내용

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- [x] `ConditionalAuthSessionRestore`에서 클라이언트 스토어가 이미 `authenticated`인 경우 
`SetUnauthenticated` 렌더링 방어 처리 추가

## 💡 작업 목적

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

**기존 문제 흐름:**
1. `/callback`에서 토큰 발급 → `authStatus = 'authenticated'`
2. `router.replace('/')` → 클라이언트 네비게이션 (layout.tsx 재실행 안 됨)
3. `isLoggedIn = false` (서버 캐시) → `SetUnauthenticated` 렌더링
4. callback에서 세팅한 `authenticated` 상태가 `unauthenticated`로 덮어써짐 → 비회원 헤더 노출

**수정 후:**
```tsx
// 클라이언트 스토어가 이미 authenticated면 초기화하지 않음
if (!isLoggedIn && authStatus !== 'authenticated') {
  return <SetUnauthenticated />;
}
```

## 🧪 테스트 결과

- 운영 서버 테스트 필요