### PR TITLE
feat: VQA 및 대기열 API 요청에 인증 헤더 추가

### DIFF
--- a/src/app/api/auth/identity/complete/route.ts
+++ b/src/app/api/auth/identity/complete/route.ts
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+        Cookie: cookieHeader!,
       },
       body: JSON.stringify({ identityVerificationId }),
       cache: 'no-store',

--- a/src/app/api/auth/identity/complete/route.ts
+++ b/src/app/api/auth/identity/complete/route.ts
@@ -48,12 +48,16 @@ export async function POST(request: NextRequest) {
     return createSessionExpiredResponse();
   }
 
+  if (!cookieHeader) {
+    return createSessionExpiredResponse();
+  }
+
   try {
     const response = await fetch(`${API_BASE_URL}/auth/identity/complete`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Cookie: cookieHeader!,
+        Cookie: cookieHeader,
       },
       body: JSON.stringify({ identityVerificationId }),
       cache: 'no-store',

--- a/src/app/api/vqa/route.ts
+++ b/src/app/api/vqa/route.ts
@@ -1,15 +1,25 @@
-import { handleProxyResponse } from '@/app/api/shared/route-helpers';
+import {
+  createUnauthorizedResponse,
+  handleProxyResponse,
+} from '@/app/api/shared/route-helpers';
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/+$/, '') ??
   'http://localhost:8084';
 
-export async function GET() {
+export async function GET(request: Request) {
   const url = `${API_BASE}/queues/vqa/start`;
+  const authorization = request.headers.get('Authorization');
+
+  if (!authorization) {
+    return createUnauthorizedResponse();
+  }
+
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: authorization,
     },
     body: JSON.stringify({ user_agent: '' }),
   });
@@ -19,11 +29,17 @@ export async function GET() {
 
 export async function POST(request: Request) {
   const body = await request.json();
+  const authorization = request.headers.get('Authorization');
+
+  if (!authorization) {
+    return createUnauthorizedResponse();
+  }
 
   const response = await fetch(`${API_BASE}/vqa`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: authorization,
     },
     body: JSON.stringify(body),
   });

--- a/src/app/vqa/containers/vqa-form.tsx
+++ b/src/app/vqa/containers/vqa-form.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Typography } from '@/components/ui/typography';
 import { snackbar } from '@/components/ui/snackbar';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
 
 interface VqaQuestion {
   failCount: number;
@@ -32,6 +33,7 @@ export default function VqaForm() {
   const [questionData, setQuestionData] = useState<VqaQuestion | null>(null);
   const [timeLeft, setTimeLeft] = useState(30);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const accessToken = useAuthStore((state) => state.accessToken);
 
   useEffect(() => {
     const fetchQuestion = async () => {
@@ -78,7 +80,10 @@ export default function VqaForm() {
     try {
       const res = await fetch('/api/vqa', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
         body: JSON.stringify({
           answer: answer.trim(),
           questionId: questionData?.questionId,

--- a/src/features/queue/components/queue-page-client.tsx
+++ b/src/features/queue/components/queue-page-client.tsx
@@ -51,8 +51,9 @@ export const QueuePageClient = () => {
       }
 
       if (!token) return;
+      if (!accessToken) return;
 
-      leaveQueueBeacon(token, accessToken!);
+      leaveQueueBeacon(token, accessToken);
       clearAuctionQueueState();
       clearDrawQueueState();
     };
@@ -62,6 +63,14 @@ export const QueuePageClient = () => {
   }, [token, accessToken]);
 
   const handleBack = async () => {
+    if (!accessToken) {
+      clearAuctionQueueState();
+      clearDrawQueueState();
+      isManualLeave.current = true;
+      router.back();
+      return;
+    }
+
     const result = await leaveQueue(token, accessToken!);
 
     switch (result.code) {

--- a/src/features/queue/components/queue-page-client.tsx
+++ b/src/features/queue/components/queue-page-client.tsx
@@ -52,17 +52,17 @@ export const QueuePageClient = () => {
 
       if (!token) return;
 
-      leaveQueueBeacon(token);
+      leaveQueueBeacon(token, accessToken!);
       clearAuctionQueueState();
       clearDrawQueueState();
     };
 
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
-  }, [token]);
+  }, [token, accessToken]);
 
   const handleBack = async () => {
-    const result = await leaveQueue(token);
+    const result = await leaveQueue(token, accessToken!);
 
     switch (result.code) {
       case 'SUCCESS':
@@ -127,7 +127,7 @@ export const QueuePageClient = () => {
 
       void rejoinQueue();
     }
-  }, [drawId, router, setDrawId]);
+  }, [drawId, router, setDrawId, accessToken]);
   // END 드로우 대기열 진입 -> 새로고침 복구
 
   // 드로우 대기열 진입 -> auction 전용 새로고침 복구
@@ -172,7 +172,7 @@ export const QueuePageClient = () => {
 
       void rejoinQueue();
     }
-  }, [auctionId, router, setAuctionId]);
+  }, [auctionId, router, setAuctionId, accessToken]);
   // END 드로우 대기열 진입 -> 새로고침 복구
 
   const { position, estimatedWaitSeconds, progress } = useQueue({

--- a/src/features/queue/hooks/use-queue.ts
+++ b/src/features/queue/hooks/use-queue.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import type { QueueStatusResponse } from '@/features/queue/types/queue';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
 
 interface UseQueueOptions {
   queueToken: string;
@@ -10,12 +11,16 @@ interface UseQueueOptions {
 export function useQueue({ queueToken, onActive }: UseQueueOptions) {
   const initialPositionRef = useRef<number | null>(null);
   const [progress, setProgress] = useState(0);
+  const accessToken = useAuthStore((state) => state.accessToken);
 
   const { data } = useQuery({
     queryKey: ['queue-status', queueToken],
     queryFn: async () => {
       const response = await fetch('/api/queue/status', {
-        headers: { 'X-Queue-Token': queueToken },
+        headers: {
+          'X-Queue-Token': queueToken,
+          Authorization: `Bearer ${accessToken}`,
+        },
       });
 
       if (!response.ok) {

--- a/src/lib/api/leave-queue.ts
+++ b/src/lib/api/leave-queue.ts
@@ -14,7 +14,8 @@ function createLeaveQueueErrorResponse(
 }
 
 export async function leaveQueue(
-  queueToken: string
+  queueToken: string,
+  accessToken: string
 ): Promise<LeaveQueueResponse> {
   //queueToken이 없으면 아예 fetch 안 보내고 바로 Q002 반환 브라우저 뒤로가기 우려
   if (!queueToken) {
@@ -28,6 +29,7 @@ export async function leaveQueue(
       method: 'DELETE',
       headers: {
         'X-Queue-Token': queueToken,
+        Authorization: `Bearer ${accessToken}`,
       },
       cache: 'no-store',
     });
@@ -43,12 +45,18 @@ export async function leaveQueue(
 }
 
 // 브라우저 뒤로가기용 (fire-and-forget, keepalive 보장)
-export function leaveQueueBeacon(queueToken: string): void {
+export function leaveQueueBeacon(
+  queueToken: string,
+  accessToken: string
+): void {
   if (!queueToken) return;
 
-  fetch(`${API_BASE_URL.replace(/\/+$/, '')}/queues`, {
+  fetch(`${API_BASE_URL}/queues`, {
     method: 'DELETE',
-    headers: { 'X-Queue-Token': queueToken },
+    headers: {
+      'X-Queue-Token': queueToken,
+      Authorization: `Bearer ${accessToken}`,
+    },
     keepalive: true,
   });
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #121 

## 📝 작업 내용

- [x] `/api/vqa` GET·POST 핸들러에 `Authorization` 헤더 미존재 시 401 즉시 반환
- [x] `/api/vqa` GET·POST 핸들러에서 `Authorization` 헤더를 백엔드로 전달
- [x] `vqa-form.tsx` — VQA 답변 제출 시 `Bearer <accessToken>` 헤더 추가
- [x] `use-queue.ts` — 큐 상태 조회(`/api/queue/status`) 요청에 `Authorization` 헤더 추가
- [x] `leave-queue.ts` — `leaveQueue`, `leaveQueueBeacon` 함수에 `accessToken` 파라미터 추가 및 `Authorization` 헤더 전달
- [x] `queue-page-client.tsx` — 위 함수 호출부에 `accessToken` 인자 전달
- [x] `/api/identity/complete` POST 핸들러에 쿠키 스프레드 방식 -> 필수로 변경

## 💡 작업 목적

- 기존에는 헤더 없이 요청이 전송되던 상태였고, 인증 추가 요청으로 작업
- API Route 레벨에서 사전 차단하고, 클라이언트에서 `useAuthStore`로 토큰을 주입하여 인증 흐름 완성

## 🧪 테스트 결과

- 운영에서 실질 QA 필요