### PR TITLE
feat: 경매/드로우 날짜·회차 API에 X-Quiz-Passed-Token 헤더 추가

### DIFF
--- a/src/app/api/auctions/[auctionId]/dates/[entryDate]/options/route.ts
+++ b/src/app/api/auctions/[auctionId]/dates/[entryDate]/options/route.ts
@@ -16,9 +16,10 @@ export async function GET(
   }
 
   const authorization = request.headers.get('Authorization');
+  const quizPassedToken = request.headers.get('X-Quiz-Passed-Token');
   const { auctionId, entryDate } = await params;
 
-  if (!authorization) {
+  if (!authorization || !quizPassedToken) {
     return createUnauthorizedResponse();
   }
 
@@ -30,6 +31,7 @@ export async function GET(
         headers: {
           'Content-Type': 'application/json',
           Authorization: authorization,
+          'X-Quiz-Passed-Token': quizPassedToken,
         },
       }
     );

--- a/src/app/api/auctions/[auctionId]/dates/route.ts
+++ b/src/app/api/auctions/[auctionId]/dates/route.ts
@@ -16,9 +16,10 @@ export async function GET(
   }
 
   const authorization = request.headers.get('Authorization');
+  const quizPassedToken = request.headers.get('X-Quiz-Passed-Token');
   const { auctionId } = await params;
 
-  if (!authorization) {
+  if (!authorization || !quizPassedToken) {
     return createUnauthorizedResponse();
   }
 
@@ -30,6 +31,7 @@ export async function GET(
         headers: {
           'Content-Type': 'application/json',
           Authorization: authorization,
+          'X-Quiz-Passed-Token': quizPassedToken,
         },
       }
     );

--- a/src/app/api/draws/[drawId]/dates/[entryDate]/options/route.ts
+++ b/src/app/api/draws/[drawId]/dates/[entryDate]/options/route.ts
@@ -16,9 +16,10 @@ export async function GET(
   }
 
   const authorization = request.headers.get('Authorization');
+  const quizPassedToken = request.headers.get('X-Quiz-Passed-Token');
   const { drawId, entryDate } = await params;
 
-  if (!authorization) {
+  if (!authorization || !quizPassedToken) {
     return createUnauthorizedResponse();
   }
 
@@ -30,6 +31,7 @@ export async function GET(
         headers: {
           'Content-Type': 'application/json',
           Authorization: authorization,
+          'X-Quiz-Passed-Token': quizPassedToken,
         },
       }
     );

--- a/src/app/api/draws/[drawId]/dates/route.ts
+++ b/src/app/api/draws/[drawId]/dates/route.ts
@@ -16,9 +16,10 @@ export async function GET(
   }
 
   const authorization = request.headers.get('Authorization');
+  const quizPassedToken = request.headers.get('X-Quiz-Passed-Token');
   const { drawId } = await params;
 
-  if (!authorization) {
+  if (!authorization || !quizPassedToken) {
     return createUnauthorizedResponse();
   }
 
@@ -28,6 +29,7 @@ export async function GET(
       headers: {
         'Content-Type': 'application/json',
         Authorization: authorization,
+        'X-Quiz-Passed-Token': quizPassedToken,
       },
     });
 

--- a/src/app/draw/[popupId]/reserve/page.tsx
+++ b/src/app/draw/[popupId]/reserve/page.tsx
@@ -1,9 +1,7 @@
 // 드로우
 
-import SaleTimeCountBar from '@/components/sale-detail/contents/sale-time-count-bar';
 import { Wrapper } from '@/components/layout/wrapper';
 import { DrawReservePageClient } from './components/draw-reserve-page-client';
-import { mockReserveData } from '@/app/auction/[popupId]/reserve/mock-reserve-data';
 
 export default async function DrawReservePage({
   params,

--- a/src/features/anti-macro/utils/quiz-passed-token.ts
+++ b/src/features/anti-macro/utils/quiz-passed-token.ts
@@ -1,7 +1,0 @@
-const KEY = 'quiz_passed_token';
-
-export const quizPassedTokenStorage = {
-  save: (token: string) => sessionStorage.setItem(KEY, token),
-  get: () => sessionStorage.getItem(KEY),
-  remove: () => sessionStorage.removeItem(KEY),
-};

--- a/src/features/anti-macro/utils/quiz-passed-token.ts
+++ b/src/features/anti-macro/utils/quiz-passed-token.ts
@@ -1,0 +1,7 @@
+const KEY = 'quiz_passed_token';
+
+export const quizPassedTokenStorage = {
+  save: (token: string) => sessionStorage.setItem(KEY, token),
+  get: () => sessionStorage.getItem(KEY),
+  remove: () => sessionStorage.removeItem(KEY),
+};

--- a/src/features/reserve/hooks/use-reserve-date-slots.ts
+++ b/src/features/reserve/hooks/use-reserve-date-slots.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
+import { quizPassedTokenStorage } from '@/features/anti-macro/utils/quiz-passed-token';
 
 const DEFAULT_DATES_ERROR =
   '예약 가능 날짜를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.';
@@ -36,8 +37,12 @@ export function useReserveDateSlots<TSlot>({
   const [availableDates, setAvailableDates] = useState<string[]>([]);
   const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null);
   const [slots, setSlots] = useState<TSlot[]>([]);
-  const [datesErrorMessage, setDatesErrorMessage] = useState<string | null>(null);
-  const [slotsErrorMessage, setSlotsErrorMessage] = useState<string | null>(null);
+  const [datesErrorMessage, setDatesErrorMessage] = useState<string | null>(
+    null
+  );
+  const [slotsErrorMessage, setSlotsErrorMessage] = useState<string | null>(
+    null
+  );
   const [isDatesLoading, setIsDatesLoading] = useState(true);
   const [isSlotsLoading, setIsSlotsLoading] = useState(false);
 
@@ -50,23 +55,34 @@ export function useReserveDateSlots<TSlot>({
     const fetchDates = async () => {
       setIsDatesLoading(true);
       try {
-        const response = await fetch(datesUrl, { signal: controller.signal });
+        const quizPassedToken = quizPassedTokenStorage.get();
+        const response = await fetch(datesUrl, {
+          signal: controller.signal,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'X-Quiz-Passed-Token': quizPassedToken ?? '',
+          },
+        });
         const result = await response.json();
 
         if (!response.ok) {
           setAvailableDates([]);
           setDatesErrorMessage(
-            errorCodes.includes(result.code) ? result.message : DEFAULT_DATES_ERROR
+            errorCodes.includes(result.code)
+              ? result.message
+              : DEFAULT_DATES_ERROR
           );
           return;
         }
 
         setDatesErrorMessage(null);
         setAvailableDates(
-          result.data?.map((date: { entryDate: string }) => date.entryDate) ?? []
+          result.data?.map((date: { entryDate: string }) => date.entryDate) ??
+            []
         );
       } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') return;
+        if (error instanceof DOMException && error.name === 'AbortError')
+          return;
         console.error('[useReserveDateSlots/fetchDates]', error);
         setAvailableDates([]);
         setDatesErrorMessage(DEFAULT_DATES_ERROR);
@@ -92,14 +108,21 @@ export function useReserveDateSlots<TSlot>({
       setSlotsErrorMessage(null);
       setIsSlotsLoading(true);
       try {
+        const quizPassedToken = quizPassedTokenStorage.get();
         const response = await fetch(`${datesUrl}/${selectedDate}/options`, {
           signal: controller.signal,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'X-Quiz-Passed-Token': quizPassedToken ?? '',
+          },
         });
         const result = await response.json();
 
         if (!response.ok) {
           setSlotsErrorMessage(
-            errorCodes.includes(result.code) ? result.message : DEFAULT_SLOTS_ERROR
+            errorCodes.includes(result.code)
+              ? result.message
+              : DEFAULT_SLOTS_ERROR
           );
           return;
         }
@@ -107,7 +130,8 @@ export function useReserveDateSlots<TSlot>({
         setSlotsErrorMessage(null);
         setSlots(result.data ?? []);
       } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') return;
+        if (error instanceof DOMException && error.name === 'AbortError')
+          return;
         console.error('[useReserveDateSlots/fetchSlots]', error);
         setSlotsErrorMessage(DEFAULT_SLOTS_ERROR);
       } finally {

--- a/src/features/reserve/hooks/use-reserve-date-slots.ts
+++ b/src/features/reserve/hooks/use-reserve-date-slots.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
-import { quizPassedTokenStorage } from '@/features/anti-macro/utils/quiz-passed-token';
+import { quizPassedTokenStorage } from '@/lib/utils';
 
 const DEFAULT_DATES_ERROR =
   '예약 가능 날짜를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,3 +39,11 @@ export function formatOpenAt(openAt: string) {
   }).format(date);
   return { datePart, timePart };
 }
+
+const KEY = 'quiz_passed_token';
+
+export const quizPassedTokenStorage = {
+  save: (token: string) => sessionStorage.setItem(KEY, token),
+  get: () => sessionStorage.getItem(KEY),
+  remove: () => sessionStorage.removeItem(KEY),
+};


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Related to #125

## 📝 작업 내용

**이슈 중 아래 파일 작업**
/auctions/dates
/auctions/options 
/draws/options 
/draws/entries 

- [x] `quizPassedTokenStorage` 유틸 추가 (`features/anti-macro/utils/quiz-passed-token.ts`)
- [x] `/auctions/dates` API Route에 `X-Quiz-Passed-Token` 헤더 프록시 추가
- [x] `/auctions/options` API Route에 `X-Quiz-Passed-Token` 헤더 프록시 추가
- [x] `/draws/dates` API Route에 `X-Quiz-Passed-Token` 헤더 프록시 추가
- [x] `/draws/options` API Route에 `X-Quiz-Passed-Token` 헤더 프록시 추가
- [x] `useReserveDateSlots` 훅에서 `Authorization` 및 `X-Quiz-Passed-Token` 헤더 전달

## 💡 작업 목적

- 백엔드에서 경매/드로우 API에 `quizPassedToken` 검증이 적용된 상태로, 
프론트엔드에서도 해당 토큰을 헤더에 포함하여 전달해야 정상 접근이 가능하도록 하기 위함
- 보안퀴즈 통과 여부를 API 단에서 검증하여 매크로/비정상 접근을 방지하기 위함

## 🧪 테스트 결과

(아래 운영에서 테스트 필요)
- [ ] 보안퀴즈 통과 후 토큰이 sessionStorage에 정상 저장되는지 확인
- [ ] 날짜 목록 조회 시 `X-Quiz-Passed-Token` 헤더가 백엔드까지 전달되는지 확인
- [ ] 회차 목록 조회 시 `X-Quiz-Passed-Token` 헤더가 백엔드까지 전달되는지 확인

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> `quizPassedTokenStorage`의 sessionStorage key(`quiz_passed_token`)가 
저장 key와 일치하는지 확인 부탁드립니다~!