### PR TITLE
feat: 카테고리 섹션 API 연동

### DIFF
--- a/src/app/(home)/components/category-list.tsx
+++ b/src/app/(home)/components/category-list.tsx
@@ -1,34 +1,64 @@
-import Link from 'next/link';
-import { Box } from '@/components/ui/box';
+'use client';
 
-const MAIN_CATEGORIES = [
-  { id: 1, name: '전체' },
-  { id: 2, name: '팝업스토어' },
-  { id: 3, name: '체험존' },
-  { id: 4, name: '전시' },
-  { id: 5, name: '푸드' },
-  { id: 6, name: '키즈' },
-];
+import Link from 'next/link';
+import { useSectionFetch } from '../hooks/use-section-fetch';
+import { CategoryListSkeleton } from './skeletons';
+import { useRouter } from 'next/navigation';
+import { PopupPhase } from '../types';
+
+interface CategoryItem {
+  iconUrl: string | null;
+  iconName: string;
+  popupId: number;
+  phase: PopupPhase;
+}
+
+const CATEGORY_LIMIT = 6;
 
 export const CategoryList = () => {
+  const categories = useSectionFetch<CategoryItem>(
+    `/api/popups/categories?limit=${CATEGORY_LIMIT}`
+  );
+
+  const router = useRouter();
+
+  if (categories === null) return <CategoryListSkeleton />;
+  if (categories.length === 0) return null;
+
+  const handleBannersClick = (
+    popupId: number,
+    phaseType: 'AUCTION' | 'DRAW'
+  ) => {
+    if (phaseType === 'AUCTION') {
+      router.push(`/auction/${popupId}`);
+    } else {
+      router.push(`/draw/${popupId}`);
+    }
+  };
+
   return (
     <div className="flex justify-center items-center flex-wrap gap-10 my-3xl">
-      {MAIN_CATEGORIES.map((category) => (
-        <Link
-          key={category.id}
-          href={`/category/${category.id}`}
-          className="flex flex-col items-center basis-auto"
+      {categories.map((category) => (
+        <div
+          key={category.iconName}
+          onClick={() =>
+            handleBannersClick(category.popupId, category.phase.type)
+          }
+          className="flex flex-col items-center basis-auto cursor-pointer"
         >
-          <Box
-            className="mb-2 flex h-20 w-20 items-center justify-center rounded-xl bg-gray-100 text-sm text-gray-500"
-            aria-hidden="true"
-          >
-            {category.name.slice(0, 2)}
-          </Box>
+          <div className="mb-2 flex h-20 w-20 items-center justify-center rounded-xl bg-gray-100 overflow-hidden">
+            <img
+              src={category.iconUrl ?? '/images/temp/no-image.png'}
+              alt={category.iconName}
+              width={80}
+              height={80}
+              className="object-cover w-full h-full"
+            />
+          </div>
           <span className="text-Contents-High text-base font-normal leading-6">
-            {category.name}
+            {category.iconName}
           </span>
-        </Link>
+        </div>
       ))}
     </div>
   );

--- a/src/app/(home)/components/category-list.tsx
+++ b/src/app/(home)/components/category-list.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { useSectionFetch } from '../hooks/use-section-fetch';
 import { CategoryListSkeleton } from './skeletons';
-import { useRouter } from 'next/navigation';
 import { PopupPhase } from '../types';
 
 interface CategoryItem {
@@ -20,30 +19,18 @@ export const CategoryList = () => {
     `/api/popups/categories?limit=${CATEGORY_LIMIT}`
   );
 
-  const router = useRouter();
-
   if (categories === null) return <CategoryListSkeleton />;
   if (categories.length === 0) return null;
 
-  const handleBannersClick = (
-    popupId: number,
-    phaseType: 'AUCTION' | 'DRAW'
-  ) => {
-    if (phaseType === 'AUCTION') {
-      router.push(`/auction/${popupId}`);
-    } else {
-      router.push(`/draw/${popupId}`);
-    }
-  };
+  const getCategoryHref = (popupId: number, phaseType: PopupPhase['type']) =>
+    phaseType === 'AUCTION' ? `/auction/${popupId}` : `/draw/${popupId}`;
 
   return (
     <div className="flex justify-center items-center flex-wrap gap-10 my-3xl">
       {categories.map((category) => (
-        <div
-          key={category.iconName}
-          onClick={() =>
-            handleBannersClick(category.popupId, category.phase.type)
-          }
+        <Link
+          key={category.popupId}
+          href={getCategoryHref(category.popupId, category.phase.type)}
           className="flex flex-col items-center basis-auto cursor-pointer"
         >
           <div className="mb-2 flex h-20 w-20 items-center justify-center rounded-xl bg-gray-100 overflow-hidden">
@@ -58,7 +45,7 @@ export const CategoryList = () => {
           <span className="text-Contents-High text-base font-normal leading-6">
             {category.iconName}
           </span>
-        </div>
+        </Link>
       ))}
     </div>
   );

--- a/src/app/(home)/components/skeletons.tsx
+++ b/src/app/(home)/components/skeletons.tsx
@@ -25,6 +25,18 @@ const CardSkeleton = ({ ratio }: { ratio: '3/4' | '16/9' }) => (
   </div>
 );
 
+/** 카테고리 리스트 */
+export const CategoryListSkeleton = () => (
+  <div className="flex justify-center items-center flex-wrap gap-10 my-3xl">
+    {Array.from({ length: 6 }).map((_, i) => (
+      <div key={i} className="flex flex-col items-center gap-2">
+        <SkeletonBlock className="h-20 w-20 rounded-xl" />
+        <SkeletonBlock className="h-4 w-12 rounded" />
+      </div>
+    ))}
+  </div>
+);
+
 /** 메인 배너 */
 export const MainBannerSkeleton = () => (
   <div className="flex gap-6 justify-center overflow-hidden">

--- a/src/app/api/popups/categories/route.ts
+++ b/src/app/api/popups/categories/route.ts
@@ -1,8 +1,9 @@
+import { NextResponse } from 'next/server';
 import {
   createBadRequestResponse,
   createServerErrorResponse,
   getServiceBaseUrl,
-  handleProxyResponse,
+  safeParseResponseBody,
 } from '../../shared/route-helpers';
 
 const API_BASE_URL = getServiceBaseUrl('popup');
@@ -38,7 +39,27 @@ export async function GET(request: Request) {
         cache: 'no-store',
       }
     );
-    return handleProxyResponse(response);
+
+    if (response.status >= 500) {
+      return createServerErrorResponse();
+    }
+
+    const body = (await safeParseResponseBody(response)) as {
+      data?: {
+        items?: { isActive?: boolean }[];
+        itemCount?: number;
+      };
+    };
+
+    if (response.ok && Array.isArray(body?.data?.items)) {
+      const activeItems = body.data.items.filter(
+        (item: { isActive?: boolean }) => item.isActive !== false
+      );
+      body.data.items = activeItems;
+      body.data.itemCount = activeItems.length;
+    }
+
+    return NextResponse.json(body, { status: response.status });
   } catch (error) {
     console.error('[GET /api/popups/categories]', error);
     return createServerErrorResponse('시스템 오류가 발생했습니다.');

--- a/src/app/api/popups/categories/route.ts
+++ b/src/app/api/popups/categories/route.ts
@@ -1,0 +1,46 @@
+import {
+  createBadRequestResponse,
+  createServerErrorResponse,
+  getServiceBaseUrl,
+  handleProxyResponse,
+} from '../../shared/route-helpers';
+
+const API_BASE_URL = getServiceBaseUrl('popup');
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 6;
+
+export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const authorization = request.headers.get('Authorization');
+  const { searchParams } = new URL(request.url);
+
+  const rawLimit = searchParams.get('limit') ?? String(MAX_LIMIT);
+  const limit = Number(rawLimit);
+
+  if (!Number.isInteger(limit) || limit < MIN_LIMIT || limit > MAX_LIMIT) {
+    return createBadRequestResponse({
+      limit: `limit는 ${MIN_LIMIT} 이상 ${MAX_LIMIT} 이하여야 합니다.`,
+    });
+  }
+
+  searchParams.set('limit', String(limit));
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/popups/categories?${searchParams}`,
+      {
+        headers: {
+          ...(authorization && { Authorization: authorization }),
+        },
+        cache: 'no-store',
+      }
+    );
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[GET /api/popups/categories]', error);
+    return createServerErrorResponse('시스템 오류가 발생했습니다.');
+  }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #129

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] GET /api/popups/categories Route Handler 구현 (limit 유효성 검사 포함)
- [x] CategoryList 컴포넌트에서 카테고리 목록 조회 및 렌더링
- [x] iconUrl=null 시 기본 이미지 대체 노출 처리 (/temp/no-image.png 적용 -> 기본 대체 이미지 있는지 확인 필요)
- [x] 카테고리 아이콘 클릭 시 popupId 기반 팝업 상세 화면으로 라우팅 (AUCTION / DRAW 분기)
- [x] 로딩 상태 스켈레톤 UI 적용

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 실제 서버 데이터를 연동하여 사용자에게 팝업 진입점 카테고리를 제공
- limit 파라미터 유효성(1~6)을 Route Handler에서 검증하여 
잘못된 요청이 백엔드까지 전달되지 않도록 방어

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [x] 카테고리 목록이 priority 순으로 최대 6개 정상 노출 확인
- [x] iconUrl=null 카테고리에서 기본 이미지 대체 노출 확인
- [x] 아이콘 클릭 시 AUCTION → /auction/{popupId}, DRAW → /draw/{popupId} 라우팅 확인
- [x] 로딩 중 스켈레톤 UI 정상 노출 확인

## 📷 스크린샷 (선택)

<img width="1172" height="590" alt="스크린샷 2026-04-12 오후 3 20 17" src="https://github.com/user-attachments/assets/d5256599-cfe9-4c06-8167-872b27dabe0b" />
