### PR TITLE
feat: 마이페이지 프로필 API 연동 및 실데이터 적용

### DIFF
--- a/src/app/(protected)/mypage/_main/components/profile-summary-section.tsx
+++ b/src/app/(protected)/mypage/_main/components/profile-summary-section.tsx
@@ -1,9 +1,12 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
 import type { IconName } from '@/components/Icon/Icon';
 import { Icon } from '@/components/Icon/Icon';
 import { Box } from '@/components/ui/box';
 import { Typography } from '@/components/ui/typography';
+import { useUserMeQuery } from '@/features/user/queries/use-user-me-query';
 
 const summaryCards: {
   label: string;
@@ -25,7 +28,19 @@ const summaryStats: { label: string; value: number }[] = [
   { label: '찜한 수', value: 12 },
 ];
 
+const FALLBACK_PROFILE_IMAGE = '/images/temp/no-image.png';
+
 export function ProfileSummarySection() {
+  const { data: userMe } = useUserMeQuery();
+
+  const profileImage = userMe?.profileImage || FALLBACK_PROFILE_IMAGE;
+  const nickname = userMe?.nickname ?? '';
+  const email = userMe?.email ?? '';
+  const phone = userMe?.phone ?? '';
+  const joinDate = userMe?.joinDate
+    ? `가입일 ${userMe.joinDate.replace(/-/g, '.')}`
+    : '';
+
   return (
     <section className="space-y-2">
       {/* 프로필 */}
@@ -40,7 +55,7 @@ export function ProfileSummarySection() {
           <div className="flex items-center gap-4">
             <Box radius="FULL" className="h-[72px] w-[72px] overflow-hidden">
               <Image
-                src="/images/temp/God-Sang-hyeok.png"
+                src={profileImage}
                 alt="프로필 이미지"
                 width={72}
                 height={72}
@@ -49,22 +64,22 @@ export function ProfileSummarySection() {
             </Box>
             <div className="space-y-2">
               <Typography variant="title-1" weight="medium">
-                심심한 고래
+                {nickname}
               </Typography>
               <div className="flex flex-col text-[var(--neutral-60)] md:flex-row md:flex-wrap md:items-center">
                 <Typography
                   variant="body-1"
                   className="after:mx-2 after:content-['|'] last:after:hidden after:text-[#0A0A0A]/8"
                 >
-                  account@mail.com
+                  {email}
                 </Typography>
                 <Typography
                   variant="body-1"
                   className="after:mx-2 after:content-['|'] last:after:hidden after:text-[#0A0A0A]/8"
                 >
-                  010-1234-5678
+                  {phone}
                 </Typography>
-                <Typography variant="body-1">가입일 2025.01.01</Typography>
+                <Typography variant="body-1">{joinDate}</Typography>
               </div>
             </div>
           </div>

--- a/src/app/(protected)/mypage/info/profile/components/profile-summary-card-client.tsx
+++ b/src/app/(protected)/mypage/info/profile/components/profile-summary-card-client.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useUserMeQuery } from '@/features/user/queries/use-user-me-query';
+import { ProfileSummaryCard } from './profile-summary-card';
+
+const FALLBACK_PROFILE_IMAGE = '/images/temp/God-Sang-hyeok.png';
+
+export function ProfileSummaryCardClient() {
+  const { data: userMe } = useUserMeQuery();
+
+  const profileImage = userMe?.profileImage || FALLBACK_PROFILE_IMAGE;
+  const nickname = userMe?.nickname ?? '';
+  const birthDate = userMe?.birthDate
+    ? userMe.birthDate.replace(/-/g, '.')
+    : '';
+
+  const infoItems = [
+    { label: '이름', value: userMe?.name ?? '' },
+    { label: '생년월일', value: birthDate },
+    { label: '휴대폰 번호', value: userMe?.phone ?? '' },
+    { label: '이메일', value: userMe?.email ?? '' },
+  ];
+
+  return (
+    <ProfileSummaryCard
+      imageSrc={profileImage}
+      nickname={nickname}
+      infoItems={infoItems}
+    />
+  );
+}

--- a/src/app/(protected)/mypage/info/profile/components/profile-summary-card-client.tsx
+++ b/src/app/(protected)/mypage/info/profile/components/profile-summary-card-client.tsx
@@ -3,7 +3,7 @@
 import { useUserMeQuery } from '@/features/user/queries/use-user-me-query';
 import { ProfileSummaryCard } from './profile-summary-card';
 
-const FALLBACK_PROFILE_IMAGE = '/images/temp/God-Sang-hyeok.png';
+const FALLBACK_PROFILE_IMAGE = '/images/temp/no-image.png';
 
 export function ProfileSummaryCardClient() {
   const { data: userMe } = useUserMeQuery();

--- a/src/app/(protected)/mypage/info/profile/page.tsx
+++ b/src/app/(protected)/mypage/info/profile/page.tsx
@@ -1,14 +1,5 @@
 import { PageHeader } from '@/components/shared/page-header';
-import { ProfileSummaryCard } from '@/app/(protected)/mypage/info/profile/components/profile-summary-card';
-import type { ProfileInfoItem } from '@/app/(protected)/mypage/info/profile/components/profile-summary-card';
-
-// TODO: 하드코딩 데이터를 실제 사용자 정보로 교체 필요
-const PROFILE_INFO: ProfileInfoItem[] = [
-  { label: '이름', value: '이상혁' },
-  { label: '생년월일', value: '1996.05.07' },
-  { label: '휴대폰 번호', value: '010-1234-5678' },
-  { label: '이메일', value: 'account@mail.com' },
-];
+import { ProfileSummaryCardClient } from './components/profile-summary-card-client';
 
 export default function MyPageProfilePage() {
   return (
@@ -18,11 +9,7 @@ export default function MyPageProfilePage() {
         titleVariant="heading-1"
         titleWeight="bold"
       />
-      <ProfileSummaryCard
-        imageSrc="/images/temp/God-Sang-hyeok.png"
-        nickname="심심한 고래"
-        infoItems={PROFILE_INFO}
-      />
+      <ProfileSummaryCardClient />
     </section>
   );
 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,35 @@
+import {
+  createServerErrorResponse,
+  createUnauthorizedResponse,
+  getServiceBaseUrl,
+  handleProxyResponse,
+} from '../../shared/route-helpers';
+
+const API_BASE_URL = getServiceBaseUrl('user');
+
+export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const authorization = request.headers.get('Authorization');
+
+  if (!authorization) {
+    return createUnauthorizedResponse();
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/users/me`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authorization,
+      },
+      cache: 'no-store',
+    });
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[GET /api/users/me]', error);
+    return createServerErrorResponse('시스템 오류가 발생했습니다.');
+  }
+}

--- a/src/features/user/api/get-user-me.ts
+++ b/src/features/user/api/get-user-me.ts
@@ -1,0 +1,45 @@
+import { COMMON_ERROR_MESSAGES } from '@/constants/error/common';
+import { ApiError } from '@/lib/api-error';
+import type { UserMeResponse, UserMeErrorResponse } from '../types/user-me';
+
+export async function getUserMe(accessToken: string) {
+  let response: Response;
+
+  try {
+    response = await fetch('/api/users/me', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      cache: 'no-store',
+    });
+  } catch {
+    throw new ApiError({
+      code: 'NETWORK_ERROR',
+      message: COMMON_ERROR_MESSAGES.NETWORK_ERROR,
+    });
+  }
+
+  let result: UserMeResponse | UserMeErrorResponse;
+
+  try {
+    result = (await response.json()) as UserMeResponse | UserMeErrorResponse;
+  } catch {
+    throw new ApiError({
+      code: 'INVALID_JSON',
+      message: COMMON_ERROR_MESSAGES.INVALID_JSON,
+      status: response.status,
+    });
+  }
+
+  if (result.code !== 'SUCCESS') {
+    throw new ApiError({
+      code: result.code,
+      message: result.message ?? COMMON_ERROR_MESSAGES.UNKNOWN_ERROR,
+      status: response.status,
+    });
+  }
+
+  return (result as UserMeResponse).data;
+}

--- a/src/features/user/queries/use-user-me-query.ts
+++ b/src/features/user/queries/use-user-me-query.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import { getUserMe } from '../api/get-user-me';
+
+export function useUserMeQuery() {
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  return useQuery({
+    queryKey: ['user', 'me'],
+    queryFn: () => getUserMe(accessToken!),
+    enabled: !!accessToken,
+  });
+}

--- a/src/features/user/types/user-me.ts
+++ b/src/features/user/types/user-me.ts
@@ -1,0 +1,23 @@
+export type UserMe = {
+  id: number;
+  name: string;
+  nickname: string;
+  email: string;
+  phone: string;
+  birthDate: string;
+  gender: 'MALE' | 'FEMALE';
+  profileImage: string;
+  joinDate: string;
+};
+
+export type UserMeResponse = {
+  code: 'SUCCESS';
+  message: string;
+  data: UserMe;
+};
+
+export type UserMeErrorResponse = {
+  code: string;
+  message: string;
+  data: null;
+};


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #131

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] Next.js API Route 프록시 생성 (`/api/users/me`)
- [x] 사용자 프로필 타입 정의 (`features/user/types/user-me.ts`)
- [x] `getUserMe` fetch 함수 구현 (`features/user/api/get-user-me.ts`)
- [x] `useUserMeQuery` TanStack Query 훅 구현 (`features/user/queries/use-user-me-query.ts`)
- [x] 마이페이지 메인 `ProfileSummarySection` 실데이터 연결
- [x] 프로필 관리 페이지 `ProfileSummaryCardClient` 생성 및 실데이터 연결

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 마이페이지 메인, 프로필 관리 두 페이지에서 하드코딩된 사용자 정보를 실제 API 데이터로 교체
- 두 페이지가 동일한 `queryKey: ['user', 'me']`를 공유하므로 API 호출 1회로 캐시 재사용
- `features/auth/`와 동일한 도메인 분리 패턴으로 `features/user/` 구성

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

(운영에서 확인 필요)
- [ ] 마이페이지 메인에서 닉네임, 이메일, 전화번호, 가입일 실데이터 표시 확인
- [ ] 프로필 관리 페이지에서 이름, 생년월일, 전화번호, 이메일 실데이터 표시 확인