### PR TITLE
feat: 마이페이지 > 결제수단 관리 api 연동

### DIFF
--- a/src/app/(protected)/mypage/info/payment-methods/components/payment-method-card.tsx
+++ b/src/app/(protected)/mypage/info/payment-methods/components/payment-method-card.tsx
@@ -1,22 +1,14 @@
-import Image from 'next/image';
 import { Box } from '@/components/ui/box';
 import { Typography } from '@/components/ui/typography';
 import { Button } from '@/components/ui/button';
-
-// TODO PaymentAvatar PR 승인되면 해당 컴포넌트에 맞게 교체 필요 #68
-export type CardBrandCode = 'HYUNDAI' | 'TOSS';
+import { PaymentAvatar } from '@/components/ui/avatar/payment';
 
 export type PaymentMethod = {
   id: number;
-  brandCode: CardBrandCode;
+  brandCode: string;
   brand: string;
   maskedNumber: string;
   isPrimary: boolean;
-};
-
-const CARD_BRAND_IMAGE: Record<CardBrandCode, string> = {
-  HYUNDAI: '/images/temp/hyundai-card.png',
-  TOSS: '/images/temp/toss-card.png',
 };
 
 export function PaymentMethodCard({
@@ -35,13 +27,7 @@ export function PaymentMethodCard({
     <Box as="article" radius="ML" border="#0A0A0A14" paddingY="MS" paddingX="M">
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-4">
-          <Image
-            src={CARD_BRAND_IMAGE[brandCode]}
-            alt={`${brand} 로고`}
-            width={30}
-            height={47}
-            className="h-[47px] w-[30px] rounded-[2px] object-cover"
-          />
+          <PaymentAvatar brandCode={brandCode} size="LG" />
 
           <div className="min-w-0">
             <Typography

--- a/src/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client.tsx
+++ b/src/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   PaymentMethodCard,
   type PaymentMethod,
@@ -28,18 +28,53 @@ function billingCardToPaymentMethod(card: BillingCard): PaymentMethod {
   };
 }
 
-type PaymentMethodsPageClientProps = {
-  initialPaymentMethods: PaymentMethod[];
-};
-
-export function PaymentMethodsPageClient({
-  initialPaymentMethods,
-}: PaymentMethodsPageClientProps) {
-  const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>(
-    initialPaymentMethods
-  );
+export function PaymentMethodsPageClient() {
+  const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const accessToken = useAuthStore((state) => state.accessToken);
   const clearAccessToken = useAuthStore((state) => state.clearAccessToken);
+
+  const handleAuthError = useCallback(
+    (data: { code?: string }) => {
+      if (data.code === 'A002' || data.code === 'A003') {
+        clearAccessToken();
+        snackbar.destructive({
+          title: '세션 만료',
+          description: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+        });
+        return true;
+      }
+      return false;
+    },
+    [clearAccessToken]
+  );
+
+  const fetchBillingList = useCallback(async () => {
+    if (!accessToken) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const billingCards: BillingCard[] = await getBillingList(accessToken);
+      setPaymentMethods(billingCards.map(billingCardToPaymentMethod));
+    } catch (error) {
+      console.error(
+        '[PaymentMethodsPageClient] fetch billing list failed:',
+        error
+      );
+      snackbar.destructive({
+        title: '조회 실패',
+        description: '결제수단 목록을 불러오지 못했습니다.',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    fetchBillingList();
+  }, [fetchBillingList]);
 
   const handleRegisterClick = async () => {
     if (!accessToken) {
@@ -72,15 +107,7 @@ export function PaymentMethodsPageClient({
       const data = await response.json();
 
       if (!response.ok) {
-        if (data.code === 'A002' || data.code === 'A003') {
-          clearAccessToken();
-
-          snackbar.destructive({
-            title: '세션 만료',
-            description: '로그인이 만료되었습니다. 다시 로그인해주세요.',
-          });
-          return;
-        }
+        if (handleAuthError(data)) return;
 
         if (data.code === API_ERROR_CODES.COMMON.BAD_REQUEST) {
           snackbar.destructive({
@@ -124,33 +151,122 @@ export function PaymentMethodsPageClient({
     }
   };
 
-  const handleSetPrimary = (paymentMethodId: number) => {
-    setPaymentMethods((prev) =>
-      prev.map((paymentMethod) => ({
-        ...paymentMethod,
-        isPrimary: paymentMethod.id === paymentMethodId,
-      }))
-    );
+  const handleSetPrimary = async (paymentMethodId: number) => {
+    if (!accessToken) return;
+
+    try {
+      const response = await fetch(
+        `/api/billing/keys/${paymentMethodId}/default`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        if (handleAuthError(data)) return;
+
+        snackbar.destructive({
+          title: '변경 실패',
+          description: '주 결제수단 변경 중 오류가 발생했습니다.',
+        });
+        return;
+      }
+
+      setPaymentMethods((prev) =>
+        prev.map((pm) => ({
+          ...pm,
+          isPrimary: pm.id === paymentMethodId,
+        }))
+      );
+
+      snackbar.success({
+        title: '변경 완료',
+        description: '주 결제수단이 변경되었습니다.',
+      });
+    } catch (error) {
+      console.error('[PaymentMethodsPageClient] set primary failed:', error);
+      snackbar.destructive({
+        title: '변경 실패',
+        description: '주 결제수단 변경 중 오류가 발생했습니다.',
+      });
+    }
   };
 
-  const handleDelete = (paymentMethodId: number) => {
-    setPaymentMethods((previous) =>
-      previous.filter((paymentMethod) => paymentMethod.id !== paymentMethodId)
-    );
+  const handleDelete = async (paymentMethodId: number) => {
+    if (!accessToken) return;
+
+    try {
+      const response = await fetch(`/api/billing/keys/${paymentMethodId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        if (handleAuthError(data)) return;
+
+        snackbar.destructive({
+          title: '삭제 실패',
+          description: '결제수단 삭제 중 오류가 발생했습니다.',
+        });
+        return;
+      }
+
+      setPaymentMethods((prev) =>
+        prev.filter((pm) => pm.id !== paymentMethodId)
+      );
+
+      snackbar.success({
+        title: '삭제 완료',
+        description: '결제수단이 삭제되었습니다.',
+      });
+    } catch (error) {
+      console.error('[PaymentMethodsPageClient] delete failed:', error);
+      snackbar.destructive({
+        title: '삭제 실패',
+        description: '결제수단 삭제 중 오류가 발생했습니다.',
+      });
+    }
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Typography variant="body-2" className="text-[var(--neutral-50)]">
+          결제수단을 불러오는 중...
+        </Typography>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 xl:grid-cols-2">
-        {paymentMethods.map((paymentMethod) => (
-          <PaymentMethodCard
-            key={paymentMethod.id}
-            {...paymentMethod}
-            onSetPrimary={handleSetPrimary}
-            onDelete={handleDelete}
-          />
-        ))}
-      </div>
+      {paymentMethods.length === 0 ? (
+        <div className="flex justify-center py-10">
+          <Typography variant="body-2" className="text-[var(--neutral-50)]">
+            등록된 결제수단이 없습니다.
+          </Typography>
+        </div>
+      ) : (
+        <div className="grid gap-4 xl:grid-cols-2">
+          {paymentMethods.map((paymentMethod) => (
+            <PaymentMethodCard
+              key={paymentMethod.id}
+              {...paymentMethod}
+              onSetPrimary={handleSetPrimary}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
 
       <Button size="large" variant="tertiary" onClick={handleRegisterClick}>
         <Icon name="Plus" size={20} />

--- a/src/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client.tsx
+++ b/src/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client.tsx
@@ -59,6 +59,11 @@ export function PaymentMethodsPageClient() {
       const billingCards: BillingCard[] = await getBillingList(accessToken);
       setPaymentMethods(billingCards.map(billingCardToPaymentMethod));
     } catch (error) {
+      // 인증 오류인 경우 세션 만료 처리
+      if (error instanceof Error && handleAuthError({ code: error.message })) {
+        return;
+      }
+
       console.error(
         '[PaymentMethodsPageClient] fetch billing list failed:',
         error

--- a/src/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client.tsx
+++ b/src/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client.tsx
@@ -63,10 +63,6 @@ export function PaymentMethodsPageClient() {
         '[PaymentMethodsPageClient] fetch billing list failed:',
         error
       );
-      snackbar.destructive({
-        title: '조회 실패',
-        description: '결제수단 목록을 불러오지 못했습니다.',
-      });
     } finally {
       setIsLoading(false);
     }

--- a/src/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client.tsx
+++ b/src/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client.tsx
@@ -8,6 +8,25 @@ import {
 import { Icon } from '@/components/Icon/Icon';
 import { Typography } from '@/components/ui/typography';
 import { Button } from '@/components/ui/button';
+import { GrpcErrorCode, isIssueBillingKeyError } from '@portone/browser-sdk/v2';
+import { requestBillingKey } from '@/app/api/payment/request-billing-key';
+import { getBillingList } from '@/app/api/payment/get-billing-list';
+import {
+  useAuthStore,
+  type BillingCard,
+} from '@/features/auth/stores/auth-store';
+import { snackbar } from '@/components/ui/snackbar';
+import { API_ERROR_CODES } from '@/constants/api';
+
+function billingCardToPaymentMethod(card: BillingCard): PaymentMethod {
+  return {
+    id: card.id,
+    brandCode: card.cardName,
+    brand: card.cardName,
+    maskedNumber: card.cardNumber,
+    isPrimary: card.isDefault,
+  };
+}
 
 type PaymentMethodsPageClientProps = {
   initialPaymentMethods: PaymentMethod[];
@@ -19,6 +38,91 @@ export function PaymentMethodsPageClient({
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>(
     initialPaymentMethods
   );
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const clearAccessToken = useAuthStore((state) => state.clearAccessToken);
+
+  const handleRegisterClick = async () => {
+    if (!accessToken) {
+      snackbar.destructive({
+        title: '인증 오류',
+        description: '로그인 정보가 없습니다. 다시 로그인해주세요.',
+      });
+      return;
+    }
+
+    try {
+      const billingKey = await requestBillingKey();
+
+      // 사용자가 취소한 경우 — 스낵바 없이 종료
+      if (billingKey === undefined) {
+        return;
+      }
+
+      const response = await fetch(`/api/billing/keys`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          customerUid: billingKey,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        if (data.code === 'A002' || data.code === 'A003') {
+          clearAccessToken();
+
+          snackbar.destructive({
+            title: '세션 만료',
+            description: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+          });
+          return;
+        }
+
+        if (data.code === API_ERROR_CODES.COMMON.BAD_REQUEST) {
+          snackbar.destructive({
+            title: '등록 실패',
+            description: '빌링키 정보가 올바르지 않습니다.',
+          });
+          return;
+        }
+
+        snackbar.destructive({
+          title: '등록 실패',
+          description: '결제수단 등록 중 오류가 발생했습니다.',
+        });
+        return;
+      }
+
+      const billingCards: BillingCard[] = await getBillingList(accessToken);
+      setPaymentMethods(billingCards.map(billingCardToPaymentMethod));
+
+      snackbar.success({
+        title: '등록 완료',
+        description: '결제수단이 등록되었습니다.',
+      });
+    } catch (error) {
+      // 포트원 팝업이 강제로 닫힌 경우 (Cancelled) — 스낵바 없이 종료
+      if (
+        isIssueBillingKeyError(error) &&
+        error.code === GrpcErrorCode.Cancelled
+      ) {
+        return;
+      }
+
+      console.error(
+        '[PaymentMethodsPageClient] billing register failed:',
+        error
+      );
+      snackbar.destructive({
+        title: '등록 실패',
+        description: '결제수단 등록 중 오류가 발생했습니다.',
+      });
+    }
+  };
 
   const handleSetPrimary = (paymentMethodId: number) => {
     setPaymentMethods((prev) =>
@@ -48,8 +152,7 @@ export function PaymentMethodsPageClient({
         ))}
       </div>
 
-      {/* TODO 새 결제수단 등록 기능 구현 필요 */}
-      <Button size="large" variant="tertiary" disabled>
+      <Button size="large" variant="tertiary" onClick={handleRegisterClick}>
         <Icon name="Plus" size={20} />
         <Typography variant="label-1" weight="medium">
           새 결제수단 등록

--- a/src/app/(protected)/mypage/info/payment-methods/page.tsx
+++ b/src/app/(protected)/mypage/info/payment-methods/page.tsx
@@ -1,51 +1,6 @@
 import { PageHeader } from '@/components/shared/page-header';
 import { PaymentMethodsPageClient } from '@/app/(protected)/mypage/info/payment-methods/components/payment-methods-page-client';
 
-const paymentMethods = [
-  {
-    id: 1,
-    brandCode: 'HYUNDAI' as const,
-    brand: '현대카드',
-    maskedNumber: '****-****-****-1234',
-    isPrimary: true,
-  },
-  {
-    id: 2,
-    brandCode: 'TOSS' as const,
-    brand: '토스카드',
-    maskedNumber: '****-****-****-1234',
-    isPrimary: false,
-  },
-  {
-    id: 3,
-    brandCode: 'HYUNDAI' as const,
-    brand: '현대카드',
-    maskedNumber: '****-****-****-1234',
-    isPrimary: false,
-  },
-  {
-    id: 4,
-    brandCode: 'TOSS' as const,
-    brand: '토스카드',
-    maskedNumber: '****-****-****-1234',
-    isPrimary: false,
-  },
-  {
-    id: 5,
-    brandCode: 'HYUNDAI' as const,
-    brand: '현대카드',
-    maskedNumber: '****-****-****-1234',
-    isPrimary: false,
-  },
-  {
-    id: 6,
-    brandCode: 'TOSS' as const,
-    brand: '토스카드',
-    maskedNumber: '****-****-****-1234',
-    isPrimary: false,
-  },
-];
-
 export default function MyPageInfoPaymentMethodsPage() {
   return (
     <>
@@ -55,7 +10,7 @@ export default function MyPageInfoPaymentMethodsPage() {
         titleWeight="bold"
       />
 
-      <PaymentMethodsPageClient initialPaymentMethods={paymentMethods} />
+      <PaymentMethodsPageClient />
     </>
   );
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #136

## 📝 작업 내용

- [x] page.tsx에서 하드코딩된 mock 데이터(6개) 제거
- [x] 컴포넌트 마운트 시 GET /billing/my API로 결제수단 목록 조회
- [x] 주 결제수단 변경 시 PATCH /api/billing/keys/[id]/default API 호출
- [x] 결제수단 삭제 시 DELETE /api/billing/keys/[id] API 호출
- [x] 로딩 상태("결제수단을 불러오는 중...") 및 빈 상태("등록된 결제수단이 없습니다.") UI 추가
- [x] 세션 만료(A002/A003) 에러 핸들링을 handleAuthError로 공통화

## 💡 작업 목적

- mock 데이터로 인해 실제 사용자 결제수단이 표시되지 않던 문제 해결
- 주 결제수단 변경/삭제가 UI에서만 동작하고 서버에 반영되지 않던 문제 해결
- 세션 만료 처리 로직 중복 제거

## 🧪 테스트 결과

(운영에서 테스트 필요)
- [ ] 로그인 후 마이페이지 > 결제수단 관리 진입 시 실제 데이터 표시 확인
- [ ] 결제수단 미등록 시 빈 상태 메시지 표시 확인
- [ ] 주 결제수단 변경 후 서버 반영 및 "주 사용" 뱃지 이동 확인
- [ ] 결제수단 삭제 후 서버 반영 및 목록에서 제거 확인
- [ ] 토큰 만료 시 "세션 만료" 스낵바 표시 확인