### PR TITLE
feat: 마이페이지 찜한 팝업스토어 목록 API 연동

### DIFF
--- a/src/app/(protected)/mypage/_main/components/liked-popups-section.tsx
+++ b/src/app/(protected)/mypage/_main/components/liked-popups-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { Icon } from '@/components/Icon/Icon';
 import { LikedPopupCard } from '@/app/(protected)/mypage/components/liked-popup-card';
 import { PageHeader } from '@/components/shared/page-header';
@@ -11,6 +11,19 @@ import { LikedPopup, LikedPopupsData } from '../../types/liked-popup';
 
 const PAGE = 0;
 const SIZE = 8;
+
+function LikedPopupCardSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="aspect-[3/4] rounded-[var(--radius-ML)] bg-[var(--neutral-90)]" />
+      <div className="mt-2 space-y-1.5">
+        <div className="h-4 w-3/4 rounded bg-[var(--neutral-90)]" />
+        <div className="h-3 w-1/2 rounded bg-[var(--neutral-90)]" />
+        <div className="h-3 w-1/3 rounded bg-[var(--neutral-90)]" />
+      </div>
+    </div>
+  );
+}
 
 export function LikedPopupsSection() {
   const [popups, setPopups] = useState<LikedPopup[] | null>(null);
@@ -94,17 +107,4 @@ export function LikedPopupsSection() {
       )}
     </section>
   );
-
-  function LikedPopupCardSkeleton() {
-    return (
-      <div className="animate-pulse">
-        <div className="aspect-[3/4] rounded-[var(--radius-ML)] bg-[var(--neutral-90)]" />
-        <div className="mt-2 space-y-1.5">
-          <div className="h-4 w-3/4 rounded bg-[var(--neutral-90)]" />
-          <div className="h-3 w-1/2 rounded bg-[var(--neutral-90)]" />
-          <div className="h-3 w-1/3 rounded bg-[var(--neutral-90)]" />
-        </div>
-      </div>
-    );
-  }
 }

--- a/src/app/(protected)/mypage/_main/components/liked-popups-section.tsx
+++ b/src/app/(protected)/mypage/_main/components/liked-popups-section.tsx
@@ -1,17 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Icon } from '@/components/Icon/Icon';
 import { LikedPopupCard } from '@/app/(protected)/mypage/components/liked-popup-card';
 import { PageHeader } from '@/components/shared/page-header';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import type { ApiResponse } from '@/types/api/common';
+import { LikedPopup, LikedPopupsData } from '../../types/liked-popup';
 
-const likedPopups = Array.from({ length: 8 }, (_, index) => ({
-  id: index + 1,
-  title: `POP-CON STORE ${index + 1}`,
-  description: '지금 가장 인기 있는 팝업',
-  caption: '서울 성동구 성수동',
-  thumbnailUrl: '/images/temp/no-image.png',
-}));
+const PAGE = 0;
+const SIZE = 8;
 
 export function LikedPopupsSection() {
+  const [popups, setPopups] = useState<LikedPopup[] | null>(null);
+  const [isError, setIsError] = useState(false);
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  useEffect(() => {
+    if (!accessToken) return;
+
+    const controller = new AbortController();
+
+    const fetchLikedPopups = async () => {
+      try {
+        const response = await fetch(
+          `/api/history/likes?page=${PAGE}&size=${SIZE}`,
+          {
+            signal: controller.signal,
+            headers: { Authorization: `Bearer ${accessToken}` },
+          }
+        );
+
+        if (!response.ok) {
+          setIsError(true);
+          return;
+        }
+
+        const result = (await response.json()) as ApiResponse<LikedPopupsData>;
+        setPopups(result.data?.content ?? []);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError')
+          return;
+        setIsError(true);
+      }
+    };
+
+    fetchLikedPopups();
+    return () => controller.abort();
+  }, [accessToken]);
+
+  if (isError) {
+    return null;
+  }
+
   return (
     <section>
       <div className="mb-6 flex items-center justify-between gap-4">
@@ -29,17 +71,40 @@ export function LikedPopupsSection() {
         </Link>
       </div>
 
-      <div className="grid grid-cols-1 gap-x-2 gap-y-6 sm:grid-cols-2 xl:grid-cols-4">
-        {likedPopups.map((popup) => (
-          <LikedPopupCard
-            key={popup.id}
-            title={popup.title}
-            description={popup.description}
-            caption={popup.caption}
-            thumbnailUrl={popup.thumbnailUrl}
-          />
-        ))}
-      </div>
+      {popups !== null && popups.length === 0 ? (
+        <div className="min-h-[200px] flex items-center justify-center text-[var(--content-extra-low)]">
+          찜한 팝업스토어가 없어요.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-x-2 gap-y-6 sm:grid-cols-2 xl:grid-cols-4">
+          {popups === null
+            ? Array.from({ length: SIZE }).map((_, i) => (
+                <LikedPopupCardSkeleton key={i} />
+              ))
+            : popups.map((popup) => (
+                <LikedPopupCard
+                  key={popup.popupId}
+                  title={popup.title}
+                  description={popup.supportingText}
+                  caption={popup.caption}
+                  thumbnailUrl={popup.thumbnailUrl}
+                />
+              ))}
+        </div>
+      )}
     </section>
   );
+
+  function LikedPopupCardSkeleton() {
+    return (
+      <div className="animate-pulse">
+        <div className="aspect-[3/4] rounded-[var(--radius-ML)] bg-[var(--neutral-90)]" />
+        <div className="mt-2 space-y-1.5">
+          <div className="h-4 w-3/4 rounded bg-[var(--neutral-90)]" />
+          <div className="h-3 w-1/2 rounded bg-[var(--neutral-90)]" />
+          <div className="h-3 w-1/3 rounded bg-[var(--neutral-90)]" />
+        </div>
+      </div>
+    );
+  }
 }

--- a/src/app/(protected)/mypage/activity/liked-popups/page.tsx
+++ b/src/app/(protected)/mypage/activity/liked-popups/page.tsx
@@ -1,15 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import { LikedPopupCard } from '@/app/(protected)/mypage/components/liked-popup-card';
 import { PageHeader } from '@/components/shared/page-header';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import type { ApiResponse } from '@/types/api/common';
+import type { LikedPopup, LikedPopupsData } from '../../types/liked-popup';
 
-const likedPopups = Array.from({ length: 12 }, (_, index) => ({
-  id: index + 1,
-  title: `Title ${index + 1}`,
-  description: `Sub Text ${index + 1}`,
-  caption: `Caption ${index + 1}`,
-  thumbnailUrl: '/images/temp/no-image.png',
-}));
+const PAGE = 0;
+const SIZE = 12;
 
 export default function MyPageActivityLikedPopupsPage() {
+  const [popups, setPopups] = useState<LikedPopup[] | null>(null);
+  const [isError, setIsError] = useState(false);
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  useEffect(() => {
+    if (!accessToken) return;
+
+    const controller = new AbortController();
+
+    const fetchLikedPopups = async () => {
+      try {
+        const response = await fetch(
+          `/api/history/likes?page=${PAGE}&size=${SIZE}`,
+          {
+            signal: controller.signal,
+            headers: { Authorization: `Bearer ${accessToken}` },
+          }
+        );
+
+        if (!response.ok) {
+          setIsError(true);
+          return;
+        }
+
+        const result = (await response.json()) as ApiResponse<LikedPopupsData>;
+        setPopups(result.data?.content ?? []);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError')
+          return;
+        setIsError(true);
+      }
+    };
+
+    fetchLikedPopups();
+    return () => controller.abort();
+  }, [accessToken]);
+
   return (
     <section>
       <PageHeader
@@ -17,17 +55,47 @@ export default function MyPageActivityLikedPopupsPage() {
         titleVariant="heading-1"
         titleWeight="bold"
       />
+
+      {isError && (
+        <div className="min-h-[200px] flex items-center justify-center text-[var(--content-extra-low)]">
+          찜한 팝업스토어를 불러오지 못했어요.
+        </div>
+      )}
+
+      {!isError && popups !== null && popups.length === 0 && (
+        <div className="min-h-[200px] flex items-center justify-center text-[var(--content-extra-low)]">
+          찜한 팝업스토어가 없어요.
+        </div>
+      )}
+
       <div className="grid grid-cols-1 gap-x-2 gap-y-6 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-        {likedPopups.map((popup) => (
-          <LikedPopupCard
-            key={popup.id}
-            title={popup.title}
-            description={popup.description}
-            caption={popup.caption}
-            thumbnailUrl={popup.thumbnailUrl}
-          />
-        ))}
+        {popups === null && !isError
+          ? Array.from({ length: SIZE }).map((_, i) => (
+              <LikedPopupCardSkeleton key={i} />
+            ))
+          : popups?.map((popup) => (
+              <LikedPopupCard
+                key={popup.popupId}
+                title={popup.title}
+                description={popup.supportingText}
+                caption={popup.caption}
+                thumbnailUrl={popup.thumbnailUrl}
+              />
+            ))}
       </div>
     </section>
+  );
+}
+
+function LikedPopupCardSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="aspect-[3/4] rounded-[var(--radius-ML)] bg-[var(--neutral-90)]" />
+      <div className="mt-2 space-y-1.5">
+        <div className="h-4 w-3/4 rounded bg-[var(--neutral-90)]" />
+        <div className="h-3 w-1/2 rounded bg-[var(--neutral-90)]" />
+        <div className="h-3 w-1/3 rounded bg-[var(--neutral-90)]" />
+      </div>
+    </div>
   );
 }

--- a/src/app/(protected)/mypage/types/liked-popup.ts
+++ b/src/app/(protected)/mypage/types/liked-popup.ts
@@ -13,7 +13,7 @@ export type LikedPopup = {
   overlay: {
     type: string | null;
     rank: number | null;
-  };
+  } | null;
   phase: {
     type: string;
     status: string;

--- a/src/app/(protected)/mypage/types/liked-popup.ts
+++ b/src/app/(protected)/mypage/types/liked-popup.ts
@@ -1,0 +1,31 @@
+export type LikedPopup = {
+  popupId: number;
+  title: string;
+  supportingText: string;
+  subText: string;
+  caption: string;
+  thumbnailUrl: string;
+  liked: boolean;
+  stats: {
+    likeCount: number;
+    viewCount: number;
+  };
+  overlay: {
+    type: string | null;
+    rank: number | null;
+  };
+  phase: {
+    type: string;
+    status: string;
+    openAt: string;
+    closeAt: string;
+  };
+};
+
+export type LikedPopupsData = {
+  content: LikedPopup[];
+  first: boolean;
+  last: boolean;
+  numberOfElements: number;
+  empty: boolean;
+};

--- a/src/app/api/history/likes/route.ts
+++ b/src/app/api/history/likes/route.ts
@@ -8,6 +8,10 @@ import {
 const API_BASE_URL = getServiceBaseUrl('user');
 
 export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
   const authorization = request.headers.get('Authorization');
 
   if (!authorization) {
@@ -26,6 +30,7 @@ export async function GET(request: Request) {
         headers: {
           Authorization: authorization,
         },
+        cache: 'no-store',
       }
     );
 

--- a/src/app/api/history/likes/route.ts
+++ b/src/app/api/history/likes/route.ts
@@ -1,0 +1,37 @@
+import {
+  createUnauthorizedResponse,
+  createServerErrorResponse,
+  handleProxyResponse,
+  getServiceBaseUrl,
+} from '@/app/api/shared/route-helpers';
+
+const API_BASE_URL = getServiceBaseUrl('user');
+
+export async function GET(request: Request) {
+  const authorization = request.headers.get('Authorization');
+
+  if (!authorization) {
+    return createUnauthorizedResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const page = searchParams.get('page') ?? '0';
+  const size = searchParams.get('size') ?? '12';
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/history/likes?page=${page}&size=${size}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: authorization,
+        },
+      }
+    );
+
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[GET /api/history/likes]', error);
+    return createServerErrorResponse();
+  }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #138 

## 📝 작업 내용

> 마이페이지 찜한 팝업스토어 목록을 백엔드 API(`GET /history/likes`)와 연동하여 하드코딩된 목 데이터를 실제 데이터로 교체합니다.

- [x] API Route 생성 (`src/app/api/history/likes/route.ts`)
- [x] 응답 타입 정의 (`LikedPopup`, `LikedPopupsData`)
- [x] 마이페이지 메인 `LikedPopupsSection` API 연동 (8개 미리보기)
- [x] 마이페이지 > 찜 목록 페이지 `MyPageActivityLikedPopupsPage` API 연동 
- [x] 로딩 스켈레톤 UI 적용
- [x] 빈 목록 상태 처리 ("찜한 팝업스토어가 없어요." 메시지 노출)
- [x] 에러 상태 처리

## 💡 작업 목적

- 기존 하드코딩된 목 데이터를 실제 API 데이터로 교체하여 정상적인 찜 목록 노출
- 로딩/빈 목록/에러 등 상태별 UI 제공으로 사용자 경험 개선
- 기존 `history/tickets` API Route와 동일한 패턴으로 일관성 유지

## 🧪 테스트 결과

(운영에서 테스트 필요)
- [ ] 찜한 팝업이 있는 계정으로 마이페이지 메인 / 찜 목록 페이지 데이터 정상 노출 확인
- [ ] 찜한 팝업이 없는 계정으로 빈 상태 메시지 노출 확인
- [ ] 로딩 중 스켈레톤 UI 정상 렌더링 확인
- [ ] 비로그인 상태에서 API 401 응답 처리 확인