### PR TITLE
fix: VQA video/question id 타입을 string으로 변경

### DIFF
--- a/src/app/vqa/containers/vqa-form.tsx
+++ b/src/app/vqa/containers/vqa-form.tsx
@@ -21,8 +21,8 @@ interface VqaStartData {
 
 /** 문제 정보 */
 interface VqaQuestion {
-  video: { id: number; title: string };
-  question: { id: number; text: string };
+  video: { id: string; title: string };
+  question: { id: string; text: string };
   is_exempt: boolean | null;
 }
 


### PR DESCRIPTION
## Summary
- 백엔드 VQA 응답에서 \`video.id\`, \`question.id\`가 \`number\` → \`string\`으로 변경됨
- 순차 정수 id는 예측 가능해 영상 스트리밍 보안 위험이 있어 백엔드에서 문자열로 변경
- 프론트 타입도 \`string\`으로 맞춤 (사용처는 JSON/URL 인터폴레이션이라 코드 변경 불필요)

## Test plan
- [ ] VQA 화면에서 영상 정상 재생 확인
- [ ] 오답 제출 시 다음 문제 정상 로드 확인
- [ ] 타입 에러 없이 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)