### PR TITLE
chore: 시그널 payload에서 미사용 핑거프린트 필드 제거

### DIFF
--- a/src/app/vqa/containers/vqa-form.tsx
+++ b/src/app/vqa/containers/vqa-form.tsx
@@ -21,8 +21,8 @@ interface VqaStartData {
 
 /** 문제 정보 */
 interface VqaQuestion {
-  video: { id: number; title: string };
-  question: { id: number; text: string };
+  video: { id: string; title: string };
+  question: { id: string; text: string };
   is_exempt: boolean | null;
 }
 

--- a/src/features/anti-macro/collectors/browser-fingerprint.ts
+++ b/src/features/anti-macro/collectors/browser-fingerprint.ts
@@ -23,19 +23,8 @@ async function collectFingerprint(): Promise<BrowserFingerprint> {
     webdriver: !!navigator.webdriver,
     webglRenderer,
     webglVendor,
-    userAgent: navigator.userAgent,
-    platform: navigator.platform,
     language: navigator.language,
-    languages: navigator.languages,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    screenResolution: { width: screen.width, height: screen.height },
-    colorDepth: screen.colorDepth,
-    hardwareConcurrency: navigator.hardwareConcurrency,
-    deviceMemory: (navigator as unknown as { deviceMemory?: number })
-      .deviceMemory,
-    components: Object.fromEntries(
-      Object.entries(components).map(([k, v]) => [k, v.value])
-    ),
   };
 }
 

--- a/src/features/anti-macro/types/index.ts
+++ b/src/features/anti-macro/types/index.ts
@@ -7,22 +7,15 @@ export interface SignalCollector {
 }
 
 // --- 브라우저 핑거프린트 ---
+// 백엔드 스코어링에 실제 사용되는 필드만 전송
 export type BrowserFingerprint = {
   visitorId: string;
   confidence: number;
   webdriver: boolean;
   webglRenderer: string | null;
   webglVendor: string | null;
-  userAgent: string;
-  platform: string;
   language: string;
-  languages: readonly string[];
   timezone: string;
-  screenResolution: { width: number; height: number };
-  colorDepth: number;
-  hardwareConcurrency: number;
-  deviceMemory: number | undefined;
-  components: Record<string, unknown>;
 };
 
 // --- 포인트 / 클릭 ---


### PR DESCRIPTION
## Summary
백엔드 스코어링 로직에서 실제로 사용되는 필드만 전송하도록 정리. FingerprintJS는 그대로 실행(visitorId 생성 필요)하되, payload에서 원시 컴포넌트 데이터만 제외.

**유지 필드** (스코어링에 사용)
- \`visitorId\`, \`confidence\`
- \`webdriver\` (자동화 감지)
- \`webglRenderer\`, \`webglVendor\` (가상화/헤드리스 감지)
- \`language\`, \`timezone\` (지역 감지)

**제거 필드** (백엔드에서 미사용)
- \`userAgent\`, \`platform\`, \`languages\`, \`screenResolution\`, \`colorDepth\`, \`hardwareConcurrency\`, \`deviceMemory\`
- \`components\` 전체 (fonts, canvas, audio, webGlBasics, webGlExtensions, math 등)

**효과**: 요청 크기 수십 KB → 1KB 미만

## Test plan
- [ ] VQA 정상 동작 확인 (visitorId로 매크로 점수 집계되는지)
- [ ] 네트워크 탭에서 signals payload 크기 감소 확인
- [ ] 빌드 타입 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)