### PR TITLE
chore(anti-macro): 시그널 요청 본문 gzip 압축

### DIFF
--- a/src/features/anti-macro/services/submit-signals.ts
+++ b/src/features/anti-macro/services/submit-signals.ts
@@ -6,6 +6,16 @@ type SubmitOptions = {
   userId?: string;
 };
 
+async function gzip(text: string): Promise<Blob | null> {
+  if (typeof CompressionStream === 'undefined') return null;
+  try {
+    const stream = new Blob([text]).stream().pipeThrough(new CompressionStream('gzip'));
+    return await new Response(stream).blob();
+  } catch {
+    return null;
+  }
+}
+
 /**
  * 시그널 전송 (프록시 경유)
  * 프록시 서버에 도달하면 백엔드 전달은 서버가 보장
@@ -21,11 +31,21 @@ export async function submitSignals(
     ...(options.userId && { userId: String(options.userId) }),
   };
 
+  const json = JSON.stringify(submission);
+  const compressed = await gzip(json);
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  let body: BodyInit = json;
+  if (compressed) {
+    headers['Content-Encoding'] = 'gzip';
+    body = compressed;
+  }
+
   try {
     await fetch(`${ANTI_MACRO_API_BASE}/signals`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(submission),
+      headers,
+      body,
     });
   } catch {
     // 실패해도 무시 (사일런트)


### PR DESCRIPTION
## Summary
시그널 payload를 `CompressionStream('gzip')` API로 압축해 `Content-Encoding: gzip` 헤더와 함께 전송.

- mouseMovements 등 반복 패턴 많은 필드에 gzip이 특히 효과적
- 31KB payload가 약 5-8KB로 감소 예상
- 미지원 브라우저는 비압축 fallback (기존 동작 유지)

## 선행 조건
백엔드 PR #216 (anti-macro-service)이 **먼저 배포되어 있어야 함** — gzip 해제 미들웨어 필요. 이미 머지/배포 완료 확인.

## Test plan
- [ ] 배포 후 네트워크 탭에서 `/signals` 요청 `Content-Encoding: gzip` 확인
- [ ] 요청 크기 감소 확인 (31KB → 수 KB)
- [ ] ArgoCD 로그에서 시그널 분석 정상 수행 확인
- [ ] DB `macro_detection_log`에 row 정상 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)