### PR TITLE
chore(anti-macro): 시그널 프록시 pass-through 방식으로 변경

### DIFF
--- a/src/app/api/anti-macro/signals/route.ts
+++ b/src/app/api/anti-macro/signals/route.ts
@@ -2,19 +2,21 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/+$/, '') ?? 'h
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json();
-    const userAgent = request.headers.get('user-agent') ?? '';
-    const forwardedFor = request.headers.get('x-forwarded-for') ?? '';
+    // 원본 바디/헤더 pass-through (Content-Encoding: gzip 포함)
+    const body = await request.arrayBuffer();
+    const headers: Record<string, string> = {
+      'Content-Type': request.headers.get('content-type') ?? 'application/json',
+      'User-Agent': request.headers.get('user-agent') ?? '',
+      'X-Forwarded-For': request.headers.get('x-forwarded-for') ?? '',
+    };
+    const contentEncoding = request.headers.get('content-encoding');
+    if (contentEncoding) headers['Content-Encoding'] = contentEncoding;
 
     // 즉시 200 응답 후 백엔드로 비동기 전달
     fetch(`${API_BASE}/anti-macro/signals`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': userAgent,
-        'X-Forwarded-For': forwardedFor,
-      },
-      body: JSON.stringify(body),
+      headers,
+      body,
     }).catch((e) => {
       console.error('[proxy] 백엔드 전달 실패:', e);
     });


### PR DESCRIPTION
## Summary
`/api/anti-macro/signals` 프록시가 요청 본문을 JSON 파싱 → 재직렬화하던 것을 **원본 바이너리/헤더 그대로 전달**하도록 변경.

### Before
\`\`\`ts
const body = await request.json();
fetch(..., { body: JSON.stringify(body) });  // 재직렬화 + Content-Encoding 헤더 손실 가능
\`\`\`

### After
\`\`\`ts
const body = await request.arrayBuffer();
fetch(..., {
  headers: { 'Content-Encoding': '...', ... },  // 원본 헤더 복사
  body,
});
\`\`\`

## 효과
- 불필요한 파싱/직렬화 제거
- gzip 등 Content-Encoding 헤더를 투명하게 전달
- 현재 동작(기존 코드도 운영에서 gzip 처리됨)에 영향 없이 **의도 명확화**

## Test plan
- [ ] 배포 후 `/signals` 요청 정상 처리 (로그 찍힘, DB 저장)
- [ ] 요청 헤더 `Content-Encoding: gzip` 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)