### PR TITLE
feat: 개인정보 수정 페이지 API 연동 및 휴대폰 번호 변경 구현

### DIFF
--- a/src/app/(protected)/mypage/info/profile/personal/components/personal-page-client.tsx
+++ b/src/app/(protected)/mypage/info/profile/personal/components/personal-page-client.tsx
@@ -1,16 +1,8 @@
 'use client';
 
-import { Box } from '@/components/ui/box';
-import { Button } from '@/components/ui/button';
-import { Typography } from '@/components/ui/typography';
 import { useUserMeQuery } from '@/features/user/queries/use-user-me-query';
 import { usePhoneChange } from '../hooks/use-phone-change';
-
-type PersonalProfileRow = {
-  label: string;
-  value: string;
-  action?: 'verifyPhoneChange';
-};
+import { PersonalProfileList } from './personal-profile-list';
 
 const GENDER_LABEL: Record<string, string> = {
   MALE: '남성',
@@ -30,53 +22,18 @@ export function PersonalPageClient() {
   const birthAndGender =
     birth && gender ? `${birth} / ${GENDER_LABEL[gender] ?? gender}` : birth;
 
-  const personalProfileList: PersonalProfileRow[] = [
+  const rows = [
     { label: '이름', value: nickname },
     { label: '생년월일 / 성별', value: birthAndGender },
     { label: '이메일', value: email },
-    { label: '휴대폰 번호', value: phone, action: 'verifyPhoneChange' },
+    { label: '휴대폰 번호', value: phone, action: 'verifyPhoneChange' as const },
   ];
 
   return (
-    <Box as="article" radius="ML" border="#0A0A0A14" padding="ML">
-      <dl className="space-y-8 md:space-y-6">
-        {personalProfileList.map((item) => (
-          <div
-            key={item.label}
-            className="grid items-center gap-3 min-h-[48px] md:grid-cols-[120px_minmax(0,1fr)_78px] md:gap-[80px]"
-          >
-            <dt className="text-[var(--neutral-20)]">
-              <Typography variant="body-1" as="span">
-                {item.label}
-              </Typography>
-            </dt>
-            <dd className="text-[var(--neutral-20)]">
-              <Typography variant="label-1" as="span">
-                {item.value}
-              </Typography>
-            </dd>
-            <div className="md:justify-self-end">
-              {item.action === 'verifyPhoneChange' && (
-                <Button
-                  type="button"
-                  size="large"
-                  variant="tertiary"
-                  disabled={isPending}
-                  onClick={handleClickPhoneChange}
-                >
-                  <Typography
-                    variant="label-1"
-                    weight="medium"
-                    className="whitespace-nowrap"
-                  >
-                    {isPending ? '처리 중...' : '변경'}
-                  </Typography>
-                </Button>
-              )}
-            </div>
-          </div>
-        ))}
-      </dl>
-    </Box>
+    <PersonalProfileList
+      rows={rows}
+      isPending={isPending}
+      onClickPhoneChange={handleClickPhoneChange}
+    />
   );
 }

--- a/src/app/(protected)/mypage/info/profile/personal/components/personal-page-client.tsx
+++ b/src/app/(protected)/mypage/info/profile/personal/components/personal-page-client.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Box } from '@/components/ui/box';
+import { Button } from '@/components/ui/button';
+import { Typography } from '@/components/ui/typography';
+import { useUserMeQuery } from '@/features/user/queries/use-user-me-query';
+import { usePhoneChange } from '../hooks/use-phone-change';
+
+type PersonalProfileRow = {
+  label: string;
+  value: string;
+  action?: 'verifyPhoneChange';
+};
+
+const GENDER_LABEL: Record<string, string> = {
+  MALE: '남성',
+  FEMALE: '여성',
+};
+
+export function PersonalPageClient() {
+  const { data: userMe } = useUserMeQuery();
+  const { handleClickPhoneChange, isPending } = usePhoneChange();
+
+  const nickname = userMe?.name ?? '';
+  const birth = userMe?.birthDate ?? '';
+  const gender = userMe?.gender;
+  const email = userMe?.email ?? '';
+  const phone = userMe?.phone ?? '';
+
+  const birthAndGender =
+    birth && gender ? `${birth} / ${GENDER_LABEL[gender] ?? gender}` : birth;
+
+  const personalProfileRows: PersonalProfileRow[] = [
+    { label: '이름', value: nickname },
+    { label: '생년월일 / 성별', value: birthAndGender },
+    { label: '이메일', value: email },
+    { label: '휴대폰 번호', value: phone, action: 'verifyPhoneChange' },
+  ];
+
+  return (
+    <Box as="article" radius="ML" border="#0A0A0A14" padding="ML">
+      <dl className="space-y-8 md:space-y-6">
+        {personalProfileRows.map((item) => (
+          <div
+            key={item.label}
+            className="grid items-center gap-3 min-h-[48px] md:grid-cols-[120px_minmax(0,1fr)_78px] md:gap-[80px]"
+          >
+            <dt className="text-[var(--neutral-20)]">
+              <Typography variant="body-1" as="span">
+                {item.label}
+              </Typography>
+            </dt>
+            <dd className="text-[var(--neutral-20)]">
+              <Typography variant="label-1" as="span">
+                {item.value}
+              </Typography>
+            </dd>
+            <div className="md:justify-self-end">
+              {item.action === 'verifyPhoneChange' && (
+                <Button
+                  type="button"
+                  size="large"
+                  variant="tertiary"
+                  disabled={isPending}
+                  onClick={handleClickPhoneChange}
+                >
+                  <Typography
+                    variant="label-1"
+                    weight="medium"
+                    className="whitespace-nowrap"
+                  >
+                    {isPending ? '처리 중...' : '변경'}
+                  </Typography>
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </dl>
+    </Box>
+  );
+}

--- a/src/app/(protected)/mypage/info/profile/personal/components/personal-page-client.tsx
+++ b/src/app/(protected)/mypage/info/profile/personal/components/personal-page-client.tsx
@@ -30,7 +30,7 @@ export function PersonalPageClient() {
   const birthAndGender =
     birth && gender ? `${birth} / ${GENDER_LABEL[gender] ?? gender}` : birth;
 
-  const personalProfileRows: PersonalProfileRow[] = [
+  const personalProfileList: PersonalProfileRow[] = [
     { label: '이름', value: nickname },
     { label: '생년월일 / 성별', value: birthAndGender },
     { label: '이메일', value: email },
@@ -40,7 +40,7 @@ export function PersonalPageClient() {
   return (
     <Box as="article" radius="ML" border="#0A0A0A14" padding="ML">
       <dl className="space-y-8 md:space-y-6">
-        {personalProfileRows.map((item) => (
+        {personalProfileList.map((item) => (
           <div
             key={item.label}
             className="grid items-center gap-3 min-h-[48px] md:grid-cols-[120px_minmax(0,1fr)_78px] md:gap-[80px]"

--- a/src/app/(protected)/mypage/info/profile/personal/components/personal-profile-list.tsx
+++ b/src/app/(protected)/mypage/info/profile/personal/components/personal-profile-list.tsx
@@ -1,0 +1,64 @@
+import { Box } from '@/components/ui/box';
+import { Button } from '@/components/ui/button';
+import { Typography } from '@/components/ui/typography';
+
+export type PersonalProfileRow = {
+  label: string;
+  value: string;
+  action?: 'verifyPhoneChange';
+};
+
+type PersonalProfileListProps = {
+  rows: PersonalProfileRow[];
+  isPending: boolean;
+  onClickPhoneChange: () => void;
+};
+
+export function PersonalProfileList({
+  rows,
+  isPending,
+  onClickPhoneChange,
+}: PersonalProfileListProps) {
+  return (
+    <Box as="article" radius="ML" border="#0A0A0A14" padding="ML">
+      <dl className="space-y-8 md:space-y-6">
+        {rows.map((item) => (
+          <div
+            key={item.label}
+            className="grid items-center gap-3 min-h-[48px] md:grid-cols-[120px_minmax(0,1fr)_78px] md:gap-[80px]"
+          >
+            <dt className="text-[var(--neutral-20)]">
+              <Typography variant="body-1" as="span">
+                {item.label}
+              </Typography>
+            </dt>
+            <dd className="text-[var(--neutral-20)]">
+              <Typography variant="label-1" as="span">
+                {item.value}
+              </Typography>
+            </dd>
+            <div className="md:justify-self-end">
+              {item.action === 'verifyPhoneChange' && (
+                <Button
+                  type="button"
+                  size="large"
+                  variant="tertiary"
+                  disabled={isPending}
+                  onClick={onClickPhoneChange}
+                >
+                  <Typography
+                    variant="label-1"
+                    weight="medium"
+                    className="whitespace-nowrap"
+                  >
+                    {isPending ? '처리 중...' : '변경'}
+                  </Typography>
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </dl>
+    </Box>
+  );
+}

--- a/src/app/(protected)/mypage/info/profile/personal/hooks/use-phone-change.ts
+++ b/src/app/(protected)/mypage/info/profile/personal/hooks/use-phone-change.ts
@@ -1,0 +1,151 @@
+'use client';
+
+import PortOne, {
+  GrpcErrorCode,
+  isIdentityVerificationError,
+} from '@portone/browser-sdk/v2';
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { snackbar } from '@/components/ui/snackbar';
+import { AUTH_ERROR_CODES, AUTH_MESSAGES } from '@/constants/auth';
+import { API_ERROR_CODES, API_MESSAGES } from '@/constants/api';
+import { authFetch } from '@/app/(protected)/mypage/lib/auth-fetch';
+
+const PHONE_CHANGE_ERROR_SNACKBAR: Record<
+  string,
+  { title: string; description?: string }
+> = {
+  [API_ERROR_CODES.COMMON.BAD_REQUEST]: {
+    title: API_MESSAGES.COMMON.INVALID_INPUT,
+    description: AUTH_MESSAGES.IDENTITY.ERROR.REQUIRED_ID,
+  },
+  [AUTH_ERROR_CODES.PORTONE.FETCH_FAILED]: {
+    title: '본인인증 정보 조회에 실패했습니다.',
+    description: '다시 본인인증을 진행해주세요.',
+  },
+  [AUTH_ERROR_CODES.PORTONE.VERIFY_FAILED]: {
+    title: '본인 명의의 휴대폰 번호로만 변경할 수 있습니다.',
+    description: '다시 본인인증을 진행해주세요.',
+  },
+  [AUTH_ERROR_CODES.USER.DUPLICATE_PHONE]: {
+    title: '이미 사용중인 휴대폰 번호입니다.',
+  },
+  [AUTH_ERROR_CODES.AUTH.INVALID_AUTH]: {
+    title: AUTH_MESSAGES.IDENTITY.ERROR.INVALID_AUTH,
+    description: '다시 로그인 후 시도해주세요.',
+  },
+  [AUTH_ERROR_CODES.AUTH.LOGIN_REQUIRED]: {
+    title: '인증이 만료되었습니다.',
+    description: '다시 로그인 후 시도해주세요.',
+  },
+};
+
+const storeId = process.env.NEXT_PUBLIC_PORTONE_STORE_ID;
+const channelKey = process.env.NEXT_PUBLIC_PORTONE_CHANNEL_KEY;
+
+function createIdentityVerificationId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return `identity-verification-${crypto.randomUUID()}`;
+  }
+  return `identity-verification-${Date.now()}-${Math.random()}`;
+}
+
+export function usePhoneChange() {
+  const queryClient = useQueryClient();
+  const [isPending, setIsPending] = useState(false);
+
+  const handleClickPhoneChange = async () => {
+    if (!storeId || !channelKey) {
+      snackbar.destructive({
+        title: '현재 본인인증을 진행할 수 없습니다.',
+        description: '잠시 후 다시 시도해주세요.',
+      });
+      console.error('포트원 설정값이 없습니다.');
+      return;
+    }
+
+    try {
+      setIsPending(true);
+
+      const response = await PortOne.requestIdentityVerification({
+        storeId,
+        channelKey,
+        identityVerificationId: createIdentityVerificationId(),
+      });
+
+      if (response === undefined) {
+        return;
+      }
+
+      if (response.code !== undefined) {
+        snackbar.informative({
+          title: '본인인증이 취소되었습니다.',
+          description: response.message ?? '다시 시도해주세요.',
+        });
+        return;
+      }
+
+      if (!response.identityVerificationId) {
+        snackbar.destructive({
+          title: '본인인증 결과를 확인할 수 없습니다.',
+          description: '다시 시도해주세요.',
+        });
+        return;
+      }
+
+      const phoneChangeResponse = await authFetch(
+        '/api/auth/identity/phone-change',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            identityVerificationId: response.identityVerificationId,
+          }),
+        }
+      );
+
+      const result = await phoneChangeResponse.json();
+
+      if (!phoneChangeResponse.ok) {
+        if (result.code === API_ERROR_CODES.SYSTEM.INTERNAL_SERVER_ERROR) {
+          snackbar.destructive({
+            title: '휴대폰 번호 변경에 실패했습니다.',
+            description: result.message ?? '잠시 후 다시 시도해주세요.',
+          });
+          return;
+        }
+
+        const errorEntry = PHONE_CHANGE_ERROR_SNACKBAR[result.code];
+        if (errorEntry) {
+          snackbar.destructive(errorEntry);
+          return;
+        }
+
+        console.error(result.message);
+        return;
+      }
+
+      snackbar.success({
+        title: '휴대폰 번호가 성공적으로 변경되었습니다.',
+      });
+      queryClient.invalidateQueries({ queryKey: ['user', 'me'] });
+    } catch (error) {
+      if (
+        isIdentityVerificationError(error) &&
+        error.code === GrpcErrorCode.Cancelled
+      ) {
+        return;
+      }
+
+      snackbar.destructive({
+        title: '본인인증 중 문제가 발생했습니다.',
+        description: '잠시 후 다시 시도해주세요.',
+      });
+      console.error(error);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return { handleClickPhoneChange, isPending };
+}

--- a/src/app/(protected)/mypage/info/profile/personal/hooks/use-phone-change.ts
+++ b/src/app/(protected)/mypage/info/profile/personal/hooks/use-phone-change.ts
@@ -79,7 +79,7 @@ export function usePhoneChange() {
 
       if (response.code !== undefined) {
         snackbar.informative({
-          title: '본인인증이 취소되었습니다.',
+          title: '본인인증에 실패했습니다.',
           description: response.message ?? '다시 시도해주세요.',
         });
         return;
@@ -121,6 +121,10 @@ export function usePhoneChange() {
           return;
         }
 
+        snackbar.destructive({
+          title: '휴대폰 번호 변경에 실패했습니다.',
+          description: result.message ?? '잠시 후 다시 시도해주세요.',
+        });
         console.error(result.message);
         return;
       }

--- a/src/app/(protected)/mypage/info/profile/personal/hooks/use-phone-change.ts
+++ b/src/app/(protected)/mypage/info/profile/personal/hooks/use-phone-change.ts
@@ -30,6 +30,9 @@ const PHONE_CHANGE_ERROR_SNACKBAR: Record<
   [AUTH_ERROR_CODES.USER.DUPLICATE_PHONE]: {
     title: '이미 사용중인 휴대폰 번호입니다.',
   },
+  [AUTH_ERROR_CODES.USER.SAME_PHONE]: {
+    title: '현재 사용 중인 번호와 동일합니다.',
+  },
   [AUTH_ERROR_CODES.AUTH.INVALID_AUTH]: {
     title: AUTH_MESSAGES.IDENTITY.ERROR.INVALID_AUTH,
     description: '다시 로그인 후 시도해주세요.',

--- a/src/app/(protected)/mypage/info/profile/personal/page.tsx
+++ b/src/app/(protected)/mypage/info/profile/personal/page.tsx
@@ -1,25 +1,5 @@
 import { PageHeader } from '@/components/shared/page-header';
-import { Box } from '@/components/ui/box';
-import { Button } from '@/components/ui/button';
-import { Typography } from '@/components/ui/typography';
-
-type PersonalProfileRow = {
-  label: string;
-  value: string;
-  action?: 'verifyPhone' | 'edit';
-};
-
-// TODO API 연동하여 실제 데이터로 교체 필요
-const personalProfileRows: PersonalProfileRow[] = [
-  { label: '이름', value: '이상혁' },
-  { label: '생년월일 / 성별', value: '1996.05.07 / 남' },
-  { label: '이메일', value: 'Account@mail.com' },
-  {
-    label: '휴대폰 번호',
-    value: '010-1234-5678',
-    action: 'verifyPhone',
-  },
-];
+import { PersonalPageClient } from './components/personal-page-client';
 
 export default function MyPagePersonalInfoPage() {
   return (
@@ -29,46 +9,7 @@ export default function MyPagePersonalInfoPage() {
         titleVariant="heading-1"
         titleWeight="bold"
       />
-      <Box as="article" radius="ML" border="#0A0A0A14" padding="ML">
-        <dl className="space-y-8 md:space-y-6">
-          {personalProfileRows.map((item) => (
-            <div
-              key={item.label}
-              className="grid items-center gap-3 min-h-[48px] md:grid-cols-[120px_minmax(0,1fr)_78px] md:gap-[80px]"
-            >
-              <dt className="text-[var(--neutral-20)]">
-                <Typography variant="body-1" as="span">
-                  {item.label}
-                </Typography>
-              </dt>
-              <dd className="text-[var(--neutral-20)]">
-                <Typography variant="label-1" as="span">
-                  {item.value}
-                </Typography>
-              </dd>
-              <div className="md:justify-self-end">
-                {/* TODO action에 따른 버튼 활성화 및 기능 구현 필요 */}
-                {item.action && (
-                  <Button
-                    type="button"
-                    size="large"
-                    variant="tertiary"
-                    disabled
-                  >
-                    <Typography
-                      variant="label-1"
-                      weight="medium"
-                      className="whitespace-nowrap"
-                    >
-                      변경
-                    </Typography>
-                  </Button>
-                )}
-              </div>
-            </div>
-          ))}
-        </dl>
-      </Box>
+      <PersonalPageClient />
     </>
   );
 }

--- a/src/app/api/auth/identity/phone-change/route.ts
+++ b/src/app/api/auth/identity/phone-change/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from 'next/server';
+import { AUTH_MESSAGES } from '@/constants/auth';
+import {
+  createBadRequestResponse,
+  createServerErrorResponse,
+  createUnauthorizedResponse,
+  getServiceBaseUrl,
+  handleProxyResponse,
+} from '@/app/api/shared/route-helpers';
+
+type PhoneChangeRequestBody = {
+  identityVerificationId?: string;
+};
+
+const API_BASE_URL = getServiceBaseUrl('auth');
+
+export async function POST(request: NextRequest) {
+  const authorization = request.headers.get('Authorization');
+  let identityVerificationId = '';
+
+  try {
+    const body = (await request.json()) as PhoneChangeRequestBody;
+    identityVerificationId = body.identityVerificationId?.trim() ?? '';
+  } catch {
+    return createBadRequestResponse({
+      identityVerificationId: AUTH_MESSAGES.IDENTITY.ERROR.REQUIRED_ID,
+    });
+  }
+
+  if (!identityVerificationId) {
+    return createBadRequestResponse({
+      identityVerificationId: AUTH_MESSAGES.IDENTITY.ERROR.REQUIRED_ID,
+    });
+  }
+
+  if (!authorization) {
+    return createUnauthorizedResponse();
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/auth/identity/phone-change`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authorization,
+      },
+      body: JSON.stringify({ identityVerificationId }),
+      cache: 'no-store',
+    });
+
+    console.log('[identity/phone-change] status:', response.status);
+    console.log('[identity/phone-change] body:', await response.clone().text());
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[identity/phone-change]', error);
+    return createServerErrorResponse();
+  }
+}

--- a/src/app/api/auth/identity/phone-change/route.ts
+++ b/src/app/api/auth/identity/phone-change/route.ts
@@ -48,8 +48,6 @@ export async function POST(request: NextRequest) {
       cache: 'no-store',
     });
 
-    console.log('[identity/phone-change] status:', response.status);
-    console.log('[identity/phone-change] body:', await response.clone().text());
     return handleProxyResponse(response);
   } catch (error) {
     console.error('[identity/phone-change]', error);

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -63,6 +63,7 @@ export const AUTH_ERROR_CODES = {
   USER: {
     DUPLICATE_EMAIL: 'U001', // 이미 가입된 이메일
     MISSING_SOCIAL_INFO: 'U002', // 가입 세션 소셜 정보 누락
+    DUPLICATE_PHONE: 'U004', // 이미 사용중인 휴대폰 번호
   },
 
   // 인증 및 세션 (A)

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -64,6 +64,7 @@ export const AUTH_ERROR_CODES = {
     DUPLICATE_EMAIL: 'U001', // 이미 가입된 이메일
     MISSING_SOCIAL_INFO: 'U002', // 가입 세션 소셜 정보 누락
     DUPLICATE_PHONE: 'U004', // 이미 사용중인 휴대폰 번호
+    SAME_PHONE: 'U005', // 현재 사용 중인 번호
   },
 
   // 인증 및 세션 (A)


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #158 

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] `personal/page.tsx`를 Server Component로 분리하고 로직을 `personal-page-client.tsx`로 이동
- [x] `useUserMeQuery`로 이름 / 생년월일·성별 / 이메일 / 휴대폰 번호 API 연동
- [x] 백엔드 `gender` 값(`MALE` / `FEMALE`) → 한국어(`남성` / `여성`) 변환 처리
- [x] Next.js Route Handler(`/api/auth/identity/phone-change`) 구현 — `Authorization` 헤더 기반으로 백엔드 프록시
- [x] 휴대폰 번호 변경 버튼 클릭 시 PortOne SDK 본인인증 팝업 호출 및 완료 후 번호 변경 요청
- [x] 에러 코드별 스낵바 처리 (`I002` CI 불일치, `U004` 중복 번호, `A002`/`A003` 토큰 만료 등)
- [x] 변경 성공 시 `queryClient.invalidateQueries(['user', 'me'])` 로 화면 즉시 갱신
- [x] `AUTH_ERROR_CODES.USER.DUPLICATE_PHONE` (`U004`) 상수 추가

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 개인정보 수정 페이지에 실제 사용자 데이터를 연동하여 하드코딩 제거
- PortOne 본인인증을 통한 휴대폰 번호 변경 기능으로 사용자 정보 관리 UX 개선
- 기존 회원가입 본인인증 패턴(`portone-auth-client`)과 일관된 구조로 구현

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [x] 개인정보 수정 페이지 진입 시 API 데이터 정상 렌더링 확인
- [ ] 휴대폰 번호 변경 — 백엔드 연동 완료 후 검증 예정 (현재 서버 측 `S001` 오류)