### PR TITLE
chore(vqa): 영상 우클릭(다운로드) 메뉴 차단

### DIFF
--- a/src/app/vqa/containers/vqa-form.tsx
+++ b/src/app/vqa/containers/vqa-form.tsx
@@ -343,6 +343,9 @@ export default function VqaForm() {
               muted
               loop
               playsInline
+              controlsList="nodownload"
+              disablePictureInPicture
+              onContextMenu={(e) => e.preventDefault()}
               className="w-full h-full object-cover"
             />
           </div>


### PR DESCRIPTION
## Summary
- `/vqa` 페이지 `<video>` 요소의 우클릭 컨텍스트 메뉴 차단
- `controlsList=\"nodownload\"`, `disablePictureInPicture` 속성 추가로 다운로드/PiP 경로 방어
- 문제 영상이 우클릭 → \"영상 저장...\"으로 유출되는 경로를 막기 위함

> 참고: 클라이언트 측 방어이므로 F12 네트워크 탭에서 스트림 URL을 직접 받아가는 경로는 막을 수 없음. 완전 차단이 필요하면 서버측 인증/시그니처 URL 등 별도 대응 필요.

## Test plan
- [ ] `/vqa` 접속 후 영상 위에서 우클릭 → 컨텍스트 메뉴가 뜨지 않음
- [ ] 영상 자동재생/루프 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)