### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/src/app/(protected)/mypage/components/my-page-sidebar.tsx
+++ b/src/app/(protected)/mypage/components/my-page-sidebar.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Typography } from '@/components/ui/typography';
 import { Box } from '@/components/ui/box';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import { snackbar } from '@/components/ui/snackbar';
 
 type MyPageSidebarItem = {
   label: string;
@@ -60,6 +62,10 @@ const MY_PAGE_SIDEBAR: MyPageSidebarSection[] = [
         label: '고객센터',
         href: '/support',
       },
+      {
+        label: '로그아웃',
+        href: '',
+      },
     ],
   },
 ];
@@ -70,6 +76,39 @@ const isActiveSidebarItem = (pathname: string, item: MyPageSidebarItem) => {
 
 export function MyPageSidebar() {
   const pathname = usePathname();
+  const router = useRouter();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const clearAccessToken = useAuthStore((state) => state.clearAccessToken);
+
+  const handleLogout = async () => {
+    try {
+      const response = await fetch('/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const result = (await response.json()) as {
+        code: string;
+        message: string;
+      };
+
+      if (!response.ok) {
+        snackbar.destructive({
+          title: result.message ?? '로그아웃 중 오류가 발생했습니다.',
+        });
+        return;
+      }
+
+      snackbar.success({ title: result.message ?? '로그아웃되었습니다.' });
+      clearAccessToken();
+      router.push('/');
+    } catch (error) {
+      console.error('[logout]', error);
+      snackbar.destructive({ title: '로그아웃 중 오류가 발생했습니다.' });
+    }
+  };
 
   return (
     <Box
@@ -93,25 +132,39 @@ export function MyPageSidebar() {
               {section.items.map((item) => {
                 const isActive = isActiveSidebarItem(pathname, item);
 
+                const isLogout = item.label === '로그아웃';
+
                 return (
-                  <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      aria-current={isActive ? 'page' : undefined}
-                    >
-                      <Typography
-                        variant="label-2"
-                        weight={isActive ? 'bold' : 'regular'}
-                        className={cn(
-                          'transition-colors',
-                          isActive
-                            ? 'text-[var(--orange-50)]'
-                            : 'text-[var(--neutral-60)]'
-                        )}
+                  <li key={item.label}>
+                    {isLogout ? (
+                      <button onClick={handleLogout} className="cursor-pointer">
+                        <Typography
+                          variant="label-2"
+                          weight="regular"
+                          className="text-[var(--neutral-60)] transition-colors"
+                        >
+                          {item.label}
+                        </Typography>
+                      </button>
+                    ) : (
+                      <Link
+                        href={item.href}
+                        aria-current={isActive ? 'page' : undefined}
                       >
-                        {item.label}
-                      </Typography>
-                    </Link>
+                        <Typography
+                          variant="label-2"
+                          weight={isActive ? 'bold' : 'regular'}
+                          className={cn(
+                            'transition-colors',
+                            isActive
+                              ? 'text-[var(--orange-50)]'
+                              : 'text-[var(--neutral-60)]'
+                          )}
+                        >
+                          {item.label}
+                        </Typography>
+                      </Link>
+                    )}
                   </li>
                 );
               })}

--- a/src/app/(protected)/mypage/components/my-page-sidebar.tsx
+++ b/src/app/(protected)/mypage/components/my-page-sidebar.tsx
@@ -7,6 +7,7 @@ import { Typography } from '@/components/ui/typography';
 import { Box } from '@/components/ui/box';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { snackbar } from '@/components/ui/snackbar';
+import { authFetch } from '../lib/auth-fetch';
 
 type MyPageSidebarItem = {
   label: string;
@@ -77,16 +78,12 @@ const isActiveSidebarItem = (pathname: string, item: MyPageSidebarItem) => {
 export function MyPageSidebar() {
   const pathname = usePathname();
   const router = useRouter();
-  const accessToken = useAuthStore((state) => state.accessToken);
   const clearAccessToken = useAuthStore((state) => state.clearAccessToken);
 
   const handleLogout = async () => {
     try {
-      const response = await fetch('/api/auth/logout', {
+      const response = await authFetch('/api/auth/logout', {
         method: 'POST',
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
       });
 
       const result = (await response.json()) as {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server';
+import {
+  createServerErrorResponse,
+  createUnauthorizedResponse,
+  getServiceBaseUrl,
+  handleProxyResponse,
+} from '@/app/api/shared/route-helpers';
+
+const API_BASE_URL = getServiceBaseUrl('auth');
+
+export async function POST(request: NextRequest) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const authorization = request.headers.get('Authorization');
+
+  if (!authorization) {
+    return createUnauthorizedResponse();
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/auth/logout`, {
+      method: 'POST',
+      headers: {
+        Authorization: authorization,
+      },
+      cache: 'no-store',
+    });
+
+    return handleProxyResponse(response, { withCookies: true });
+  } catch (error) {
+    console.error('[auth/logout]', error);
+    return createServerErrorResponse();
+  }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #166 

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] 로그아웃 API 프록시 라우트 구현 (`/api/auth/logout`)
- [x] `Authorization` 헤더 포함하여 백엔드 호출, 
`Set-Cookie` 응답 헤더 전달로 `refresh_token` 쿠키 만료 처리
- [x] 마이페이지 사이드바 로그아웃을 `Link` → `button`으로 변경
- [x] 로그아웃 성공 시 zustand 인증 상태 초기화(`clearAccessToken`) 후 홈으로 이동
- [x] 성공/실패 케이스별 스낵바 피드백 추가

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 로그아웃 시 서버(Redis)의 refresh token을 명시적으로 삭제하여 토큰 재사용을 방지
- 클라이언트 인증 상태(`accessToken`, `isPaymentRegistered` 등)를 완전히 초기화하여 세션 잔류 문제 방지
- API 실패 시 마이페이지에 잔류시켜 사용자가 재시도할 수 있는 UX 제공

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [x] 로그아웃 버튼 클릭 시 `/api/auth/logout` 호출 확인
- [x] 성공 응답 시 성공 스낵바 노출 후 홈으로 이동 확인
- [x] API 실패 응답 시 에러 스낵바 노출 및 마이페이지 잔류 확인
- [x] 네트워크 오류 시 에러 스낵바 노출 및 마이페이지 잔류 확인
