### PR TITLE
feat: 마이페이지 > 티켓 수정된 명세에 맞게 반영

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,13 +3,13 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   output: 'standalone',
   /* config options here */
-  reactStrictMode:false,
+  reactStrictMode: false,
   reactCompiler: true,
   images: {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'assets.popcon.store',
+        hostname: 'api.qrserver.com',
       },
       {
         protocol: 'https',

--- a/src/app/(protected)/mypage/info/tickets/[id]/components/ticket-detail-client.tsx
+++ b/src/app/(protected)/mypage/info/tickets/[id]/components/ticket-detail-client.tsx
@@ -10,17 +10,34 @@ import { Typography } from '@/components/ui/typography';
 import { Icon } from '@/components/Icon/Icon';
 import type { ApiResponse } from '@/types/api/common';
 import { TicketDetailCard } from './ticket-detail-card';
+import { authFetch } from '@/app/(protected)/mypage/lib/auth-fetch';
 
 interface TicketDetail {
   ticketId: number;
   popupId: number;
   ticketNumber: string;
-  reservationNo: string;
+  reservationNo: string | null;
   status: 'ISSUED' | 'USED' | 'CANCELLED';
+  displayStatus: string;
   sourceType: 'AUCTION' | 'DRAW';
+  sourceId: number;
   entryDate: string;
   entryTime: string;
   issuedAt: string;
+  popupTitle: string;
+  popupAddress: string;
+  thumbnailUrl: string;
+  qrValue: string;
+  userName: string;
+  userPhoneNumber: string;
+  userEmail: string;
+  paymentMethod: string | null;
+  cardName: string | null;
+  cardNumber: string | null;
+  paidAt: string;
+  originalPrice: number;
+  discountAmount: number;
+  finalPrice: number;
 }
 
 function TicketDetailSkeleton() {
@@ -32,15 +49,20 @@ function TicketDetailSkeleton() {
         <div className="w-[152px] h-[152px] rounded-[var(--radius-S)] bg-[var(--neutral-90)] animate-pulse" />
       </div>
       {Array.from({ length: 3 }).map((_, i) => (
-        <div key={i} className="h-[116px] rounded-[var(--radius-ML)] bg-[var(--neutral-90)] animate-pulse" />
+        <div
+          key={i}
+          className="h-[116px] rounded-[var(--radius-ML)] bg-[var(--neutral-90)] animate-pulse"
+        />
       ))}
     </section>
   );
 }
 
 export function TicketDetailClient() {
-  const { id: reservationNo } = useParams<{ id: string }>();
-  const [ticket, setTicket] = useState<TicketDetail | null | 'not-found' | 'error'>(null);
+  const { id: ticketId } = useParams<{ id: string }>();
+  const [ticket, setTicket] = useState<
+    TicketDetail | null | 'not-found' | 'error'
+  >(null);
   const accessToken = useAuthStore((state) => state.accessToken);
 
   useEffect(() => {
@@ -48,10 +70,9 @@ export function TicketDetailClient() {
 
     const fetchTicket = async () => {
       try {
-        const response = await fetch(
-          `/api/history/tickets/reservations/${reservationNo}`,
-          { headers: { Authorization: `Bearer ${accessToken}` } }
-        );
+        const response = await authFetch(`/api/history/tickets/${ticketId}`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
 
         if (!response.ok) {
           const result = (await response.json()) as ApiResponse<null>;
@@ -67,14 +88,18 @@ export function TicketDetailClient() {
     };
 
     fetchTicket();
-  }, [accessToken, reservationNo]);
+  }, [accessToken, ticketId]);
 
   if (ticket === 'not-found') notFound();
 
   if (ticket === 'error') {
     return (
       <section className="max-w-[760px] mx-auto">
-        <PageHeader title="내 티켓" titleVariant="heading-1" titleWeight="bold" />
+        <PageHeader
+          title="내 티켓"
+          titleVariant="heading-1"
+          titleWeight="bold"
+        />
         <div className="min-h-[200px] flex items-center justify-center text-[var(--content-extra-low)]">
           티켓 정보를 불러오지 못했어요.
         </div>
@@ -83,6 +108,8 @@ export function TicketDetailClient() {
   }
 
   if (ticket === null) return <TicketDetailSkeleton />;
+
+  console.log(ticket);
 
   return (
     <section className="max-w-[760px] space-y-3 mx-auto">
@@ -114,7 +141,7 @@ export function TicketDetailClient() {
 
         <div className="rounded-[var(--radius-s)] border-4 border-[var(--btn-primary-default)] p-4">
           <Image
-            src="/images/temp/qr-code.png"
+            src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${encodeURIComponent(ticket.qrValue)}`}
             alt="QR 코드"
             width={120}
             height={120}
@@ -127,25 +154,37 @@ export function TicketDetailClient() {
         title="팝업 정보"
         rows={[
           { label: '일시', value: `${ticket.entryDate} ${ticket.entryTime}` },
-          { label: '장소', value: 'TODO: 팝업 장소 API 연동 필요' },
+          { label: '장소', value: `${ticket.popupAddress}` },
         ]}
       />
 
       <TicketDetailCard
         title="예약자 정보"
         rows={[
-          { label: '예약자', value: 'TODO: 예약자 정보 API 연동 필요' },
-          { label: '연락처', value: 'TODO: 연락처 API 연동 필요' },
-          { label: '이메일', value: 'TODO: 이메일 API 연동 필요' },
+          { label: '예약자', value: ticket.userName },
+          { label: '연락처', value: ticket.userPhoneNumber },
+          { label: '이메일', value: ticket.userEmail },
         ]}
       />
 
       <TicketDetailCard
         title="결제 정보"
         rows={[
-          { label: '결제 수단', value: 'TODO: 결제 정보 API 연동 필요' },
-          { label: '결제 금액', value: 'TODO: 결제 금액 API 연동 필요' },
-          { label: '결제 일시', value: 'TODO: 결제 일시 API 연동 필요' },
+          {
+            label: '결제 수단',
+            value:
+              ticket.cardName && ticket.cardNumber
+                ? `${ticket.cardName} ${ticket.cardNumber}`
+                : (ticket.paymentMethod ?? '-'),
+          },
+          {
+            label: '결제 금액',
+            value: `${ticket.finalPrice.toLocaleString('ko-KR')}원`,
+          },
+          {
+            label: '결제 일시',
+            value: ticket.paidAt.replace('T', ' ').slice(0, 16),
+          },
         ]}
       />
     </section>

--- a/src/app/(protected)/mypage/info/tickets/components/ticket-card.tsx
+++ b/src/app/(protected)/mypage/info/tickets/components/ticket-card.tsx
@@ -10,6 +10,10 @@ interface Ticket {
   sourceType: 'AUCTION' | 'DRAW';
   entryDate: string;
   entryTime: string;
+  popupTitle: string;
+  popupAddress: string;
+  thumbnailUrl: string;
+  displayStatus: string;
 }
 
 interface TicketCardProps {
@@ -17,16 +21,24 @@ interface TicketCardProps {
 }
 
 export function TicketCard({ ticket }: TicketCardProps) {
+  console.log(ticket);
   const isAuction = ticket.sourceType === 'AUCTION';
 
   const content = (
     <>
-      <ThumbnailImage width={80} height={104} radius="S" />
+      <ThumbnailImage
+        src={ticket.thumbnailUrl}
+        width={80}
+        height={104}
+        radius="S"
+      />
 
       <div className="min-w-0 flex-1">
-        <Typography variant="title-2" weight="medium" className="mb-2">
-          TODO: 팝업 이름 API 연동 필요
-        </Typography>
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <Typography variant="title-2" weight="medium" className="truncate">
+            {ticket.popupTitle}
+          </Typography>
+        </div>
         <Typography variant="caption-1" className="text-[var(--neutral-60)]">
           {ticket.entryDate} {ticket.entryTime}
         </Typography>
@@ -35,7 +47,7 @@ export function TicketCard({ ticket }: TicketCardProps) {
           variant="caption-1"
           className="text-[var(--neutral-60)] mb-1"
         >
-          TODO: 팝업 장소 API 연동 필요
+          {ticket.popupAddress}
         </Typography>
         <Typography variant="caption-1" className="text-[var(--neutral-60)]">
           {isAuction
@@ -48,25 +60,12 @@ export function TicketCard({ ticket }: TicketCardProps) {
     </>
   );
 
-  const boxClassName = "flex items-center gap-4";
-
-  if (isAuction && ticket.reservationNo) {
-    return (
-      <Box
-        as="a"
-        href={`/mypage/info/tickets/${ticket.reservationNo}`}
-        radius="ML"
-        border="--neutral-90"
-        padding="M"
-        className={boxClassName}
-      >
-        {content}
-      </Box>
-    );
-  }
+  const boxClassName = 'flex items-center gap-4';
 
   return (
     <Box
+      as="a"
+      href={`/mypage/info/tickets/${ticket.ticketId}`}
       radius="ML"
       border="--neutral-90"
       padding="M"

--- a/src/app/(protected)/mypage/info/tickets/components/tickets-client.tsx
+++ b/src/app/(protected)/mypage/info/tickets/components/tickets-client.tsx
@@ -5,16 +5,25 @@ import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { PageHeader } from '@/components/shared/page-header';
 import type { ApiResponse } from '@/types/api/common';
 import { TicketCard } from './ticket-card';
+import { authFetch } from '../../../lib/auth-fetch';
+import { TicketCardSkeleton } from '../../../components/skeletons';
 
 interface Ticket {
   ticketId: number;
+  userId: number;
   popupId: number;
   ticketNumber: string;
   reservationNo: string | null;
   status: 'ISSUED' | 'USED' | 'CANCELLED';
   sourceType: 'AUCTION' | 'DRAW';
+  sourceId: number;
   entryDate: string;
   entryTime: string;
+  issuedAt: string;
+  popupTitle: string;
+  popupAddress: string;
+  thumbnailUrl: string;
+  displayStatus: string;
 }
 
 interface TicketsResponse {
@@ -24,19 +33,6 @@ interface TicketsResponse {
 
 const TICKETS_PAGE_LIMIT = 0;
 const TICKETS_SIZE_LIMIT = 20;
-
-function TicketCardSkeleton() {
-  return (
-    <div className="animate-pulse rounded-[var(--radius-ML)] border border-[var(--neutral-90)] p-4 flex items-center gap-4">
-      <div className="w-20 h-[104px] rounded-[var(--radius-S)] bg-[var(--neutral-90)]" />
-      <div className="flex-1 space-y-2">
-        <div className="h-4 w-3/4 rounded bg-[var(--neutral-90)]" />
-        <div className="h-3 w-1/2 rounded bg-[var(--neutral-90)]" />
-        <div className="h-3 w-1/3 rounded bg-[var(--neutral-90)]" />
-      </div>
-    </div>
-  );
-}
 
 export function TicketsClient() {
   const [tickets, setTickets] = useState<Ticket[] | null>(null);
@@ -48,7 +44,7 @@ export function TicketsClient() {
 
     const fetchTickets = async () => {
       try {
-        const response = await fetch(
+        const response = await authFetch(
           `/api/history/tickets?page=${TICKETS_PAGE_LIMIT}&size=${TICKETS_SIZE_LIMIT}`,
           {
             headers: { Authorization: `Bearer ${accessToken}` },

--- a/src/app/api/history/tickets/[ticketId]/route.ts
+++ b/src/app/api/history/tickets/[ticketId]/route.ts
@@ -9,19 +9,23 @@ const API_BASE_URL = getServiceBaseUrl('user');
 
 export async function GET(
   request: Request,
-  { params }: { params: Promise<{ reservationNo: string }> }
+  { params }: { params: Promise<{ ticketId: string }> }
 ) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
   const authorization = request.headers.get('Authorization');
 
   if (!authorization) {
     return createUnauthorizedResponse();
   }
 
-  const { reservationNo } = await params;
+  const { ticketId } = await params;
 
   try {
     const response = await fetch(
-      `${API_BASE_URL}/history/tickets/reservations/${reservationNo}`,
+      `${API_BASE_URL}/history/tickets/${ticketId}`,
       {
         method: 'GET',
         headers: {
@@ -32,7 +36,7 @@ export async function GET(
 
     return handleProxyResponse(response);
   } catch (error) {
-    console.error('[GET /api/history/tickets/reservations/:reservationNo]', error);
+    console.error('[GET /api/history/tickets/:ticketId]', error);
     return createServerErrorResponse();
   }
 }

--- a/src/app/api/history/tickets/route.ts
+++ b/src/app/api/history/tickets/route.ts
@@ -8,6 +8,10 @@ import {
 const API_BASE_URL = getServiceBaseUrl('user');
 
 export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
   const authorization = request.headers.get('Authorization');
 
   if (!authorization) {


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #163 

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] Ticket 인터페이스에 신규 필드 추가 (popupTitle, thumbnailUrl 등)
- [x] TicketCard에서 팝업명(기존 TODO), 썸네일 이미지 -> API 데이터로 교체
- [x] 티켓 상세 엔드포인트 변경 /history/tickets/reservations/{reservationNo} → /history/tickets/{ticketId}
- [x] TicketDetail 인터페이스에 신규 필드 추가 (displayStatus, popupTitle 등)
- [x] 티켓 상세 예약자 정보 / 결제 정보 (기존 TODO) → 실제 API 데이터 연동
- [x] Next.js API 프록시 라우트 /api/history/tickets/[ticketId]/route.ts 신규 생성

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 백엔드 API 명세 V2 변경 사항 반영
- 기존 하드코딩된 TODO 항목(팝업명, 예약자/결제 정보) 실제 데이터로 대체
- 티켓 상세 조회 식별자를 reservationNo에서 ticketId로 변경한 백엔드 정책 반영

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- 낙찰한 경매 티켓 내역 확인