### PR TITLE
feat: 마이페이지 찜한 팝업 기능 구현 및 하트 아이콘 ui 수정

### DIFF
--- a/src/app/(home)/hooks/use-popup-like.ts
+++ b/src/app/(home)/hooks/use-popup-like.ts
@@ -3,17 +3,23 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { snackbar } from '@/components/ui/snackbar';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
-import type { BasePopupCard } from '../types';
 import { deleteHomePopupLike, postHomePopupLike } from '../actions';
 import { HOME_SECTION_QUERY_KEY } from './use-section-fetch';
+import { LIKED_POPUPS_QUERY_KEY } from '@/app/(protected)/mypage/activity/liked-popups/components/liked-popups-page-client';
+
+type PopupLikeBase = {
+  popupId: number;
+  liked: boolean | null;
+  stats: { likeCount: number };
+};
 
 function isPopupCardItem(
   item: unknown,
   popupId: number
-): item is BasePopupCard {
+): item is PopupLikeBase {
   if (typeof item !== 'object' || item === null) return false;
 
-  const maybeItem = item as Partial<BasePopupCard>;
+  const maybeItem = item as Partial<PopupLikeBase>;
 
   return (
     maybeItem.popupId === popupId &&
@@ -44,7 +50,9 @@ function updatePopupLikeInItems(
   });
 }
 
-export function usePopupLike<T extends BasePopupCard>() {
+export function usePopupLike<T extends PopupLikeBase>(options?: {
+  onUnlike?: () => void;
+}) {
   const accessToken = useAuthStore((state) => state.accessToken);
   const queryClient = useQueryClient();
 
@@ -65,6 +73,7 @@ export function usePopupLike<T extends BasePopupCard>() {
     },
     onSuccess: (_, popup) => {
       updateHomeSectionQueries(popup, true);
+      queryClient.invalidateQueries({ queryKey: LIKED_POPUPS_QUERY_KEY });
     },
     onError: (error) => {
       snackbar.destructive({
@@ -86,6 +95,8 @@ export function usePopupLike<T extends BasePopupCard>() {
     },
     onSuccess: (_, popup) => {
       updateHomeSectionQueries(popup, false);
+      queryClient.invalidateQueries({ queryKey: LIKED_POPUPS_QUERY_KEY });
+      options?.onUnlike?.();
     },
     onError: (error) => {
       snackbar.destructive({

--- a/src/app/(protected)/mypage/_main/components/liked-popups-section.tsx
+++ b/src/app/(protected)/mypage/_main/components/liked-popups-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@/components/Icon/Icon';
 import { LikedPopupCard } from '@/app/(protected)/mypage/components/liked-popup-card';
 import { PageHeader } from '@/components/shared/page-header';
@@ -11,47 +11,35 @@ import { LikedPopup, LikedPopupsData } from '../../types/liked-popup';
 import { LikedPopupCardSkeleton } from '../../components/skeletons';
 import { authFetch } from '@/app/(protected)/mypage/lib/auth-fetch';
 import { useRouter } from 'next/navigation';
+import { LIKED_POPUPS_QUERY_KEY } from '../../activity/liked-popups/components/liked-popups-page-client';
+import { snackbar } from '@/components/ui/snackbar';
+import { usePopupLike } from '@/app/(home)/hooks/use-popup-like';
 
 const PAGE = 0;
 const SIZE = 8;
 
 export function LikedPopupsSection() {
-  const [popups, setPopups] = useState<LikedPopup[] | null>(null);
-  const [isError, setIsError] = useState(false);
   const accessToken = useAuthStore((state) => state.accessToken);
   const router = useRouter();
+  const { handleClickLike } = usePopupLike<LikedPopup>({
+    onUnlike: () => snackbar.success({ title: '찜 목록에서 삭제되었습니다.' }),
+  });
 
-  useEffect(() => {
-    if (!accessToken) return;
+  const { data: popups, isError } = useQuery({
+    queryKey: [...LIKED_POPUPS_QUERY_KEY, PAGE, SIZE, accessToken],
+    queryFn: async ({ signal }) => {
+      const response = await authFetch(
+        `/api/history/likes?page=${PAGE}&size=${SIZE}`,
+        { signal }
+      );
 
-    const controller = new AbortController();
+      if (!response.ok) throw new Error('Failed to fetch liked popups');
 
-    const fetchLikedPopups = async () => {
-      try {
-        const response = await authFetch(
-          `/api/history/likes?page=${PAGE}&size=${SIZE}`,
-          {
-            signal: controller.signal,
-          }
-        );
-
-        if (!response.ok) {
-          setIsError(true);
-          return;
-        }
-
-        const result = (await response.json()) as ApiResponse<LikedPopupsData>;
-        setPopups(result.data?.content ?? []);
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError')
-          return;
-        setIsError(true);
-      }
-    };
-
-    fetchLikedPopups();
-    return () => controller.abort();
-  }, [accessToken]);
+      const result = (await response.json()) as ApiResponse<LikedPopupsData>;
+      return result.data?.content ?? [];
+    },
+    enabled: Boolean(accessToken),
+  });
 
   const handleBannersClick = (
     popupId: number,
@@ -85,23 +73,24 @@ export function LikedPopupsSection() {
         <div className="min-h-[200px] flex items-center justify-center text-[var(--content-extra-low)]">
           찜한 팝업스토어를 불러오지 못했어요.
         </div>
-      ) : popups !== null && popups.length === 0 ? (
+      ) : popups !== undefined && popups.length === 0 ? (
         <div className="min-h-[200px] flex items-center justify-center text-[var(--content-extra-low)]">
           찜한 팝업스토어가 없어요.
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-x-2 gap-y-6 sm:grid-cols-2 xl:grid-cols-4">
-          {popups === null
+          {popups === undefined
             ? Array.from({ length: SIZE }).map((_, i) => (
                 <LikedPopupCardSkeleton key={i} />
               ))
-            : popups.map((popup) => (
+            : popups.map((popup: LikedPopup) => (
                 <LikedPopupCard
                   key={popup.popupId}
                   title={popup.title}
                   description={popup.supportingText}
                   caption={popup.caption}
                   thumbnailUrl={popup.thumbnailUrl}
+                  onClickLike={() => handleClickLike(popup)}
                   onClick={() =>
                     handleBannersClick(popup.popupId, popup.phase.type)
                   }

--- a/src/app/(protected)/mypage/_main/components/liked-popups-section.tsx
+++ b/src/app/(protected)/mypage/_main/components/liked-popups-section.tsx
@@ -90,6 +90,7 @@ export function LikedPopupsSection() {
                   description={popup.supportingText}
                   caption={popup.caption}
                   thumbnailUrl={popup.thumbnailUrl}
+                  isLiked={popup.liked}
                   onClickLike={() => handleClickLike(popup)}
                   onClick={() =>
                     handleBannersClick(popup.popupId, popup.phase.type)

--- a/src/app/(protected)/mypage/activity/liked-popups/components/liked-popups-page-client.tsx
+++ b/src/app/(protected)/mypage/activity/liked-popups/components/liked-popups-page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { LikedPopupCard } from '@/app/(protected)/mypage/components/liked-popup-card';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import type { ApiResponse } from '@/types/api/common';
@@ -8,53 +8,36 @@ import type { LikedPopup, LikedPopupsData } from '../../../types/liked-popup';
 import { LikedPopupCardSkeleton } from '../../../components/skeletons';
 import { useRouter } from 'next/navigation';
 import { authFetch } from '../../../lib/auth-fetch';
+import { usePopupLike } from '@/app/(home)/hooks/use-popup-like';
+import { snackbar } from '@/components/ui/snackbar';
 
 const PAGE = 0;
 const SIZE = 12;
 
+export const LIKED_POPUPS_QUERY_KEY = ['liked-popups'] as const;
+
 export function LikedPopupsPageClient() {
-  const [popups, setPopups] = useState<LikedPopup[] | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
   const accessToken = useAuthStore((state) => state.accessToken);
   const router = useRouter();
+  const { handleClickLike } = usePopupLike<LikedPopup>({
+    onUnlike: () => snackbar.success({ title: '찜 목록에서 삭제되었습니다.' }),
+  });
 
-  useEffect(() => {
-    if (!accessToken) return;
+  const { data: popups, isLoading, isError } = useQuery({
+    queryKey: [...LIKED_POPUPS_QUERY_KEY, accessToken],
+    queryFn: async ({ signal }) => {
+      const response = await authFetch(
+        `/api/history/likes?page=${PAGE}&size=${SIZE}`,
+        { signal }
+      );
 
-    const controller = new AbortController();
+      if (!response.ok) throw new Error('Failed to fetch liked popups');
 
-    const fetchLikedPopups = async () => {
-      setIsLoading(true);
-      setIsError(false);
-      try {
-        const response = await authFetch(
-          `/api/history/likes?page=${PAGE}&size=${SIZE}`,
-          {
-            signal: controller.signal,
-          }
-        );
-
-        if (!response.ok) {
-          setIsError(true);
-          return;
-        }
-
-        const result = (await response.json()) as ApiResponse<LikedPopupsData>;
-        setPopups(result.data?.content ?? []);
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError')
-          return;
-        setIsError(true);
-      } finally {
-        setIsLoading(false);
-        setIsError(false);
-      }
-    };
-
-    fetchLikedPopups();
-    return () => controller.abort();
-  }, [accessToken]);
+      const result = (await response.json()) as ApiResponse<LikedPopupsData>;
+      return result.data?.content ?? [];
+    },
+    enabled: Boolean(accessToken),
+  });
 
   if (isError) {
     return (
@@ -74,7 +57,7 @@ export function LikedPopupsPageClient() {
     );
   }
 
-  if (popups === null) return null;
+  if (!popups) return null;
 
   if (popups.length === 0) {
     return (
@@ -98,9 +81,11 @@ export function LikedPopupsPageClient() {
         <LikedPopupCard
           key={popup.popupId}
           title={popup.title}
+          isLiked={popup.liked}
           description={popup.supportingText}
           caption={popup.caption}
           thumbnailUrl={popup.thumbnailUrl}
+          onClickLike={() => handleClickLike(popup)}
           onClick={() => handleClick(popup.popupId, popup.phase.type)}
         />
       ))}

--- a/src/app/(protected)/mypage/components/liked-popup-card.tsx
+++ b/src/app/(protected)/mypage/components/liked-popup-card.tsx
@@ -30,7 +30,7 @@ export function LikedPopupCard({
       title={title}
       description={description}
       caption={caption}
-      showButtonLike={Boolean(onClickLike)}
+      showButtonLike
       showCountView
       showCountLike
       onClick={onClick}

--- a/src/components/content/card-thumbnail/index.tsx
+++ b/src/components/content/card-thumbnail/index.tsx
@@ -6,6 +6,7 @@ import { Icon } from '@/components/Icon/Icon';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Box } from '@/components/ui/box';
 import { Typography } from '@/components/ui/typography';
+import { RADIUS } from '@/constants/design-system';
 
 const thumbnailVariants = cva(
   'w-full rounded-ml border border-Line-Line-3/10 object-cover',
@@ -96,12 +97,12 @@ export const CardThumbnail: React.FC<CardThumbnailProps> = ({
         <div
           className={cn(
             'wrapper-thumbnail',
-            'self-stretch relative flex flex-col justify-start items-start gap-4 rounded-ml overflow-hidden'
+            'self-stretch relative flex flex-col justify-start items-start gap-4 overflow-hidden'
           )}
         >
           <img
             className={cn(
-              'thumbnail',
+              `thumbnail ${RADIUS.ML}`,
               thumbnailVariants({ ratio: thumbnailRatio }),
               thumbnailClassName
             )}
@@ -116,20 +117,27 @@ export const CardThumbnail: React.FC<CardThumbnailProps> = ({
               disabled={!isLikeInteractive}
               className={cn(
                 'button-like',
-                'right-0 top-0 p-4 absolute text-white',
-                isLikeInteractive
-                  ? 'cursor-pointer'
-                  : 'cursor-default opacity-70'
+                'right-0 top-0 p-4 absolute',
+                isLiked ? 'text-red-500' : 'text-white',
+                isLikeInteractive ? 'cursor-pointer' : 'cursor-default'
               )}
               onClick={handleLike}
             >
-              <Icon name={isLiked ? 'HeartFill' : 'Heart'} size={32} />
+              <Icon
+                name={isLiked ? 'HeartFill' : 'Heart'}
+                size={32}
+                className="[filter:drop-shadow(0_1px_2px_rgba(0,0,0,0.12))_drop-shadow(0_0_1px_rgba(0,0,0,0.08))]"
+              />
             </button>
           )}
           {index && (
-            <div className="w-10 h-10 p-2.5 bg-orange-500 rounded-ms inline-flex flex-col justify-center items-center text-white text-2xl font-bold absolute bottom-4 left-4">
+            <Box
+              radius="MS"
+              background="var(--orange-50)"
+              className="w-10 h-10 p-2.5 inline-flex flex-col justify-center items-center text-white text-2xl font-bold absolute bottom-4 left-4"
+            >
               {index}
-            </div>
+            </Box>
           )}
           {overlayBadge && (
             <Box


### PR DESCRIPTION
## #️⃣ 관련 이슈

N/A

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] `usePopupLike` 훅에 `onUnlike` 콜백 옵션 및 찜 목록 캐시 무효화 추가
- [x] 마이페이지 홈 찜 섹션(`LikedPopupsSection`) 데이터 페칭을 `useEffect` → `useQuery`로 리팩토링 및 찜 버튼 연동
- [x] 마이페이지 찜 목록 페이지(`LikedPopupsPageClient`) 데이터 페칭을 `useEffect` → `useQuery`로 리팩토링 및 찜 버튼 연동
- [x] `LikedPopupCard`에 찜 버튼 항상 표시하도록 변경

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 마이페이지 내 찜한 팝업 목록에서 찜 버튼을 통해 찜 취소가 가능하도록 기능 구현
- 기존 `useEffect` + `useState` 기반의 수동 fetch를 `useQuery`로 교체하여 로딩/에러 상태 관리 일원화 및 캐시 공유 (`LIKED_POPUPS_QUERY_KEY`) 활용
- 찜 취소 시 홈 섹션과 마이페이지 찜 목록 캐시를 동시에 무효화하여 UI 정합성 보장

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [x] 마이페이지 홈 → 찜한 팝업 카드에서 찜 버튼 클릭 시 찜 취소 및 스낵바 노출 확인
- [x] 마이페이지 찜 목록 페이지에서 찜 버튼 클릭 시 찜 취소 및 목록 갱신 확인
- [x] 홈 화면에서 찜 취소 시 마이페이지 찜 목록에도 반영 확인 (캐시 무효화)
