### PR TITLE
feat: 마이페이지 드로우 결과 확인하기 및 활동 통계 API 연동

### DIFF
--- a/src/app/(protected)/mypage/_main/components/activity-history-section.tsx
+++ b/src/app/(protected)/mypage/_main/components/activity-history-section.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { type KeyboardEvent, type Ref, useRef, useState } from 'react';
 import { Typography } from '@/components/ui/typography';
 import { useTabIndicator } from '@/hooks/use-tab-indicator';
@@ -19,6 +18,7 @@ import { ActivityItemSkeleton } from '../../components/skeletons';
 import {
   useDrawHistory,
   toDrawActivityItem,
+  useConfirmDrawResult,
 } from '@/app/(protected)/mypage/hooks/use-draw-history';
 import {
   useBidHistory,
@@ -36,6 +36,8 @@ const activityTabs = [
 export function ActivityHistorySection() {
   const [activeTab, setActiveTab] = useState<ActivityTab>('draw');
   const [modalResult, setModalResult] = useState<DrawResult | null>(null);
+  const { mutate: confirmResult, isPending: isConfirming } =
+    useConfirmDrawResult();
   const { indicator, setContainerRef, setItemRef } = useTabIndicator(activeTab);
   const tabButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
@@ -85,10 +87,6 @@ export function ActivityHistorySection() {
   const bidItems = (bids ?? []).slice(0, PREVIEW_COUNT).map(toBidActivityItem);
 
   const items = isDrawTab ? drawItems : bidItems;
-  const totalCount = isDrawTab ? (draws?.length ?? 0) : (bids?.length ?? 0);
-  const moreHref = isDrawTab
-    ? '/mypage/activity/draws'
-    : '/mypage/activity/bids';
 
   return (
     <section>
@@ -193,8 +191,13 @@ export function ActivityHistorySection() {
                           type="button"
                           paddingX="S"
                           radius="XS"
-                          className="bg-[var(--orange-50)] py-2 text-white flex gap-1"
-                          onClick={() => setModalResult('won')}
+                          className="bg-[var(--orange-50)] py-2 text-white flex gap-1 disabled:opacity-50"
+                          disabled={isConfirming}
+                          onClick={() =>
+                            confirmResult(item.id, {
+                              onSuccess: (result) => setModalResult(result),
+                            })
+                          }
                         >
                           <Icon
                             name="Search"
@@ -222,16 +225,6 @@ export function ActivityHistorySection() {
                     }
               }
             />
-            {totalCount > PREVIEW_COUNT && (
-              <div className="mt-6 text-center">
-                <Link
-                  href={moreHref}
-                  className="text-[var(--neutral-40)] text-sm underline underline-offset-4 hover:text-[var(--neutral-20)] transition-colors"
-                >
-                  더보기 ({totalCount}개 전체)
-                </Link>
-              </div>
-            )}
           </>
         )}
       </div>

--- a/src/app/(protected)/mypage/_main/components/profile-summary-section.tsx
+++ b/src/app/(protected)/mypage/_main/components/profile-summary-section.tsx
@@ -7,31 +7,22 @@ import { Icon } from '@/components/Icon/Icon';
 import { Box } from '@/components/ui/box';
 import { Typography } from '@/components/ui/typography';
 import { useUserMeQuery } from '@/features/user/queries/use-user-me-query';
+import { useUserStatistics } from '@/app/(protected)/mypage/hooks/use-user-statistics';
 
-const summaryCards: {
-  label: string;
-  value: string;
-  icon: IconName;
-}[] = [
-  { label: '내 티켓', value: '3', icon: 'Ticket' },
-  { label: '드로우 내역', value: '6', icon: 'Roulette' },
-  { label: '낙찰 내역', value: '2', icon: 'Gavel' },
-  { label: '작성한 리뷰', value: '2', icon: 'Like' },
-];
-
-const summaryStats: { label: string; value: number }[] = [
-  { label: '드로우 당첨', value: 1 },
-  { label: '드로우 미당첨', value: 1 },
-  { label: '진행중인 드로우', value: 1 },
-  { label: '결과 확인 대기중', value: 3 },
-  { label: '낙찰 수', value: 2 },
-  { label: '찜한 수', value: 12 },
+const SUMMARY_STATS_META: { label: string; link: string }[] = [
+  { label: '드로우 당첨', link: '/mypage/activity/draws?filter=won' },
+  { label: '드로우 미당첨', link: '/mypage/activity/draws?filter=notWon' },
+  { label: '진행중인 드로우', link: '/mypage/activity/draws?filter=inProgress' },
+  { label: '결과 확인 대기중', link: '/mypage/activity/draws?filter=pendingResult' },
+  { label: '낙찰 수', link: '/mypage/activity/bids' },
+  { label: '찜한 수', link: '/mypage/activity/liked-popups' },
 ];
 
 const FALLBACK_PROFILE_IMAGE = '/images/temp/no-image.png';
 
 export function ProfileSummarySection() {
   const { data: userMe } = useUserMeQuery();
+  const { data: statistics } = useUserStatistics();
 
   const profileImage = userMe?.profileImage || FALLBACK_PROFILE_IMAGE;
   const nickname = userMe?.nickname ?? '';
@@ -40,6 +31,25 @@ export function ProfileSummarySection() {
   const joinDate = userMe?.joinDate
     ? `가입일 ${userMe.joinDate.replace(/-/g, '.')}`
     : '';
+
+  const summaryCards: { label: string; value: number | string; icon: IconName; link: string }[] = [
+    { label: '내 티켓', value: statistics?.ticketCount ?? '-', icon: 'Ticket', link: '/mypage/info/tickets' },
+    { label: '드로우 내역', value: statistics?.totalDrawCount ?? '-', icon: 'Roulette', link: '/mypage/activity/draws' },
+    { label: '낙찰 내역', value: statistics?.totalAuctionCount ?? '-', icon: 'Gavel', link: '/mypage/activity/bids' },
+    { label: '작성한 리뷰', value: statistics?.reviewCount ?? '-', icon: 'Like', link: '/mypage/activity/reviews' },
+  ];
+
+  const summaryStats = SUMMARY_STATS_META.map((meta, i) => ({
+    ...meta,
+    value: [
+      statistics?.wonDrawCount,
+      statistics?.lostDrawCount,
+      statistics?.ongoingDrawCount,
+      statistics?.waitingResultDrawCount,
+      statistics?.wonAuctionCount,
+      statistics?.likedPopupCount,
+    ][i] ?? '-',
+  }));
 
   return (
     <section className="space-y-2">
@@ -95,7 +105,8 @@ export function ProfileSummarySection() {
       <div className="grid gap-2 xl:grid-cols-4">
         {summaryCards.map((card) => (
           <Box
-            as="article"
+            as="a"
+            href={card.link}
             key={card.label}
             radius="ML"
             border="#0A0A0A14"
@@ -129,6 +140,8 @@ export function ProfileSummarySection() {
       >
         {summaryStats.map((stat) => (
           <Box
+            as={Link}
+            href={stat.link}
             key={stat.label}
             padding="XS"
             className="
@@ -139,6 +152,7 @@ export function ProfileSummarySection() {
               after:bg-[#0A0A0A]/8
               last:after:hidden
               text-right
+              hover:opacity-70 transition-opacity
             "
           >
             <Typography variant="label-2" weight="bold">

--- a/src/app/(protected)/mypage/activity/draws/components/draws-page-client.tsx
+++ b/src/app/(protected)/mypage/activity/draws/components/draws-page-client.tsx
@@ -17,12 +17,19 @@ import { ActivityItemSkeleton } from '../../../components/skeletons';
 import {
   useDrawHistory,
   toDrawActivityItem,
+  useConfirmDrawResult,
 } from '@/app/(protected)/mypage/hooks/use-draw-history';
 
-export function DrawsPageClient() {
+type Props = {
+  initialFilter?: DrawStatusFilter | null;
+};
+
+export function DrawsPageClient({ initialFilter = null }: Props) {
   const { data: draws, isLoading, isError } = useDrawHistory();
+  const { mutate: confirmResult, isPending: isConfirming } =
+    useConfirmDrawResult();
   const [activeFilter, setActiveFilter] = useState<DrawStatusFilter | null>(
-    null
+    initialFilter
   );
   const [modalResult, setModalResult] = useState<DrawResult | null>(null);
 
@@ -33,7 +40,7 @@ export function DrawsPageClient() {
   if (isError) {
     return (
       <div className="min-h-[200px] flex items-center justify-center text-[var(--content-extra-low)]">
-        드로우 응모 내역을 불러오지 못했어요.
+        드로우 내역을 불러오지 못했어요.
       </div>
     );
   }
@@ -58,6 +65,10 @@ export function DrawsPageClient() {
 
   const items = filteredDraws.map(toDrawActivityItem);
 
+  const emptyMessage = activeFilter
+    ? `${DRAW_STATUS_FILTERS.find((f) => f.value === activeFilter)?.label} 내역이 없어요.`
+    : '드로우 응모 내역이 없어요.';
+
   return (
     <section>
       <ActivityStatusFilters
@@ -68,7 +79,7 @@ export function DrawsPageClient() {
 
       {items.length === 0 && (
         <div className="min-h-[200px] flex items-center justify-center text-[var(--content-extra-low)]">
-          드로우 응모 내역이 없어요.
+          {emptyMessage}
         </div>
       )}
 
@@ -85,8 +96,13 @@ export function DrawsPageClient() {
                 type="button"
                 paddingX="S"
                 radius="XS"
-                className="bg-[var(--orange-50)] py-2 text-white flex gap-1"
-                onClick={() => setModalResult('won')}
+                className="bg-[var(--orange-50)] py-2 text-white flex gap-1 disabled:opacity-50"
+                disabled={isConfirming}
+                onClick={() =>
+                  confirmResult(draw.id, {
+                    onSuccess: (result) => setModalResult(result),
+                  })
+                }
               >
                 <Icon name="Search" size={18} className="text-white" />
                 <Typography as="p" variant="label-3">

--- a/src/app/(protected)/mypage/activity/draws/components/draws-page-client.tsx
+++ b/src/app/(protected)/mypage/activity/draws/components/draws-page-client.tsx
@@ -66,7 +66,7 @@ export function DrawsPageClient({ initialFilter = null }: Props) {
   const items = filteredDraws.map(toDrawActivityItem);
 
   const emptyMessage = activeFilter
-    ? `${DRAW_STATUS_FILTERS.find((f) => f.value === activeFilter)?.label} 내역이 없어요.`
+    ? `${DRAW_STATUS_FILTERS.find((f) => f.value === activeFilter)?.label ?? '드로우'} 내역이 없어요.`
     : '드로우 응모 내역이 없어요.';
 
   return (

--- a/src/app/(protected)/mypage/activity/draws/page.tsx
+++ b/src/app/(protected)/mypage/activity/draws/page.tsx
@@ -1,7 +1,18 @@
 import { DrawsPageClient } from './components/draws-page-client';
 import { PageHeader } from '@/components/shared/page-header';
+import type { DrawStatusFilter } from '@/app/(protected)/mypage/lib/draw-status';
+import { DRAW_STATUS_FILTERS } from '@/app/(protected)/mypage/lib/draw-status';
 
-export default function MyPageActivityDrawsPage() {
+type Props = {
+  searchParams: Promise<{ filter?: string }>;
+};
+
+export default async function MyPageActivityDrawsPage({ searchParams }: Props) {
+  const { filter } = await searchParams;
+  const initialFilter = DRAW_STATUS_FILTERS.some((f) => f.value === filter)
+    ? (filter as DrawStatusFilter)
+    : null;
+
   return (
     <>
       <PageHeader
@@ -9,7 +20,7 @@ export default function MyPageActivityDrawsPage() {
         titleVariant="heading-1"
         titleWeight="bold"
       />
-      <DrawsPageClient />
+      <DrawsPageClient initialFilter={initialFilter} />
     </>
   );
 }

--- a/src/app/(protected)/mypage/hooks/use-draw-history.ts
+++ b/src/app/(protected)/mypage/hooks/use-draw-history.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { authFetch } from '@/app/(protected)/mypage/lib/auth-fetch';
 import { formatDate, formatWon } from '@/lib/utils';
@@ -14,6 +14,8 @@ import {
   getDrawStatusLabel,
   getDrawStatusTone,
 } from '@/app/(protected)/mypage/lib/draw-status';
+import type { DrawResult } from '@/app/(protected)/mypage/activity/draws/components/draw-result-modal';
+import { snackbar } from '@/components/ui/snackbar';
 
 export function toDrawActivityItem(item: DrawHistoryItem): ActivityItem {
   return {
@@ -40,5 +42,42 @@ export function useDrawHistory() {
       return result.data ?? [];
     },
     enabled: !!accessToken,
+  });
+}
+
+export function useConfirmDrawResult() {
+  const queryClient = useQueryClient();
+
+  return useMutation<DrawResult, Error, number>({
+    mutationFn: async (entryId: number): Promise<DrawResult> => {
+      const response = await authFetch(
+        `/api/draws/entries/${entryId}/confirm-result`,
+        { method: 'POST' }
+      );
+
+      if (response.ok) return 'won';
+
+      const result = (await response.json()) as ApiResponse<null>;
+      if (result.code === 'D008') return 'notWon';
+      if (result.code === 'D006') throw new Error('RESULT_NOT_READY');
+
+      throw new Error(result.message ?? 'confirm-result failed');
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['history', 'draws'] });
+    },
+    onError: (error) => {
+      if (error.message === 'RESULT_NOT_READY') {
+        snackbar.informative({
+          title: '아직 결과 집계 중이에요.',
+          description: '잠시 후 다시 확인해주세요.',
+        });
+        return;
+      }
+      snackbar.destructive({
+        title: '결과 확인에 실패했어요.',
+        description: '잠시 후 다시 시도해주세요.',
+      });
+    },
   });
 }

--- a/src/app/(protected)/mypage/hooks/use-user-statistics.ts
+++ b/src/app/(protected)/mypage/hooks/use-user-statistics.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import { authFetch } from '@/app/(protected)/mypage/lib/auth-fetch';
+import type { ApiResponse } from '@/types/api/common';
+import type { UserStatistics } from '@/app/(protected)/mypage/types';
+
+export function useUserStatistics() {
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  return useQuery<UserStatistics>({
+    queryKey: ['users', 'me', 'statistics'],
+    queryFn: async () => {
+      const response = await authFetch('/api/users/me/statistics');
+      if (!response.ok) throw new Error('user statistics fetch failed');
+      const result = (await response.json()) as ApiResponse<UserStatistics>;
+      return result.data!;
+    },
+    enabled: !!accessToken,
+  });
+}

--- a/src/app/(protected)/mypage/types/index.ts
+++ b/src/app/(protected)/mypage/types/index.ts
@@ -33,3 +33,16 @@ export interface BidHistoryItem {
   paidAt: string;
   displayStatus: string;
 }
+
+export interface UserStatistics {
+  ticketCount: number;
+  totalDrawCount: number;
+  totalAuctionCount: number;
+  reviewCount: number;
+  wonDrawCount: number;
+  lostDrawCount: number;
+  ongoingDrawCount: number;
+  waitingResultDrawCount: number;
+  wonAuctionCount: number;
+  likedPopupCount: number;
+}

--- a/src/app/api/draws/entries/[entryId]/confirm-result/route.ts
+++ b/src/app/api/draws/entries/[entryId]/confirm-result/route.ts
@@ -1,0 +1,42 @@
+import {
+  createUnauthorizedResponse,
+  createServerErrorResponse,
+  getServiceBaseUrl,
+  handleProxyResponse,
+} from '@/app/api/shared/route-helpers';
+
+const API_BASE_URL = getServiceBaseUrl('draw');
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ entryId: string }> }
+) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const authorization = request.headers.get('Authorization');
+  const { entryId } = await params;
+
+  if (!authorization) {
+    return createUnauthorizedResponse();
+  }
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/draws/entries/${entryId}/confirm-result`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: authorization,
+        },
+      }
+    );
+
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[POST /api/draws/entries/[entryId]/confirm-result]', error);
+    return createServerErrorResponse();
+  }
+}

--- a/src/app/api/users/me/statistics/route.ts
+++ b/src/app/api/users/me/statistics/route.ts
@@ -1,0 +1,35 @@
+import {
+  createServerErrorResponse,
+  createUnauthorizedResponse,
+  getServiceBaseUrl,
+  handleProxyResponse,
+} from '@/app/api/shared/route-helpers';
+
+const API_BASE_URL = getServiceBaseUrl('user');
+
+export async function GET(request: Request) {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  const authorization = request.headers.get('Authorization');
+
+  if (!authorization) {
+    return createUnauthorizedResponse();
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/users/me/statistics`, {
+      method: 'GET',
+      headers: {
+        Authorization: authorization,
+      },
+      cache: 'no-store',
+    });
+
+    return handleProxyResponse(response);
+  } catch (error) {
+    console.error('[GET /api/users/me/statistics]', error);
+    return createServerErrorResponse();
+  }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #187 
> Closes #156 

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [x] `POST /draws/entries/{entryId}/confirm-result` Next.js route handler 생성
- [x] `useConfirmDrawResult` mutation 훅 추가 (당첨 / 낙첨 / 집계중 분기 처리)
- [x] 드로우 내역 & 메인 대시보드 결과 확인하기 버튼에 실제 API 연동
- [x] D006(집계중) 응답 시 스낵바 안내 처리, 버튼 유지
- [x] 마이페이지 지표 API 연동 및 항목 클릭 시 드로우 내역 필터 탭으로 이동 (쿼리스트링 활용)
- [x] 드로우 내역 빈 상태 메시지 활성 탭에 맞게 동적 처리

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

결과 확인하기 버튼이 하드코딩(`'won'`)으로 박혀 있던 것을 실제 API와 연동하고,
마이페이지 대시보드에서 드로우 상태별 진입점을 제공합니다.

또한, 마이페이지 지표에 하드코딩으로 박혀 있던 것을 실제 API와 연동하기 위함입니다.

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

- [x] 결과 확인하기 클릭 → D006 응답 시 스낵바 노출 및 버튼 유지 확인
- [x] 마이페이지 대시보드 드로우 당첨 클릭 → 드로우 내역 페이지 + 당첨 탭 활성화 확인

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

현재 `GET /history/draws` 응답에서 `announcementAt`, `resultAvailable`, `resultChecked`, `clickable` 4개 필드가 누락되어 있습니다. (백엔드 user-service DTO 불일치 이슈)

이로 인해 결과 확인 버튼 노출 조건을 `clickable` 필드 대신 `status` 값 추론으로 임시 처리하고 있습니다.
백엔드 픽스 완료 후 `DrawHistoryItem` 타입 추가 및 `isResultPending` 조건 교체 재작업 예정입니다.