### PR TITLE
feat: 마이페이지 드로우 내역 > 누락되었던 백엔드 필드 반영

### DIFF
--- a/src/app/(protected)/mypage/_main/components/activity-history-section.tsx
+++ b/src/app/(protected)/mypage/_main/components/activity-history-section.tsx
@@ -35,7 +35,10 @@ const activityTabs = [
 
 export function ActivityHistorySection() {
   const [activeTab, setActiveTab] = useState<ActivityTab>('draw');
-  const [modalResult, setModalResult] = useState<DrawResult | null>(null);
+  const [modalResult, setModalResult] = useState<{
+    result: DrawResult;
+    winningRatePercent: string | null;
+  } | null>(null);
   const { mutate: confirmResult, isPending: isConfirming } =
     useConfirmDrawResult();
   const { indicator, setContainerRef, setItemRef } = useTabIndicator(activeTab);
@@ -195,7 +198,12 @@ export function ActivityHistorySection() {
                           disabled={isConfirming}
                           onClick={() =>
                             confirmResult(item.id, {
-                              onSuccess: (result) => setModalResult(result),
+                              onSuccess: (payload) =>
+                                setModalResult({
+                                  result: payload.result,
+                                  winningRatePercent:
+                                    payload.winningRatePercent,
+                                }),
                             })
                           }
                         >
@@ -232,7 +240,8 @@ export function ActivityHistorySection() {
       {modalResult && (
         <DrawResultModal
           isOpen={!!modalResult}
-          result={modalResult}
+          result={modalResult.result}
+          winningRatePercent={modalResult.winningRatePercent}
           onClose={() => setModalResult(null)}
         />
       )}

--- a/src/app/(protected)/mypage/activity/draws/components/draw-result-modal.tsx
+++ b/src/app/(protected)/mypage/activity/draws/components/draw-result-modal.tsx
@@ -12,32 +12,45 @@ type DrawResultModalProps = {
   isOpen: boolean;
   onClose: () => void;
   result: DrawResult;
+  winningRatePercent?: string | null;
 };
 
-const RESULT_CONFIG: Record<
-  DrawResult,
-  { title: string; description: string }
-> = {
-  lucky: {
-    title: '축하해요!',
-    description: '상위 13%의 행운을 잡으셨어요',
-  },
-  won: {
-    title: '축하해요!',
-    description: '드로우에 당첨되었어요',
-  },
-  notWon: {
+function getResult(
+  result: DrawResult,
+  winningRatePercent?: string | null
+): {
+  title: string;
+  description: string;
+} {
+  if (result === 'lucky') {
+    return {
+      title: '축하해요!',
+      description: winningRatePercent
+        ? `상위 ${winningRatePercent}의 행운을 잡으셨어요`
+        : `상위권의 행운을 잡으셨어요`,
+    };
+  }
+
+  if (result === 'won') {
+    return {
+      title: '축하해요!',
+      description: '드로우에 당첨되었어요',
+    };
+  }
+
+  return {
     title: '아쉽지만 이번 드로우에는',
     description: '당첨되지 않았어요',
-  },
-};
+  };
+}
 
 export default function DrawResultModal({
   isOpen,
   onClose,
   result,
+  winningRatePercent,
 }: DrawResultModalProps) {
-  const { title, description } = RESULT_CONFIG[result];
+  const { title, description } = getResult(result, winningRatePercent);
 
   return (
     <Modal

--- a/src/app/(protected)/mypage/activity/draws/components/draws-page-client.tsx
+++ b/src/app/(protected)/mypage/activity/draws/components/draws-page-client.tsx
@@ -130,6 +130,7 @@ export function DrawsPageClient({ initialFilter = null }: Props) {
         <DrawResultModal
           isOpen={!!modalResult}
           result={modalResult.result}
+          winningRatePercent={modalResult.winningRatePercent}
           onClose={() => setModalResult(null)}
         />
       )}

--- a/src/app/(protected)/mypage/activity/draws/components/draws-page-client.tsx
+++ b/src/app/(protected)/mypage/activity/draws/components/draws-page-client.tsx
@@ -31,7 +31,10 @@ export function DrawsPageClient({ initialFilter = null }: Props) {
   const [activeFilter, setActiveFilter] = useState<DrawStatusFilter | null>(
     initialFilter
   );
-  const [modalResult, setModalResult] = useState<DrawResult | null>(null);
+  const [modalResult, setModalResult] = useState<{
+    result: DrawResult;
+    winningRatePercent: string | null;
+  } | null>(null);
 
   const handleToggle = (value: DrawStatusFilter) => {
     setActiveFilter((prev) => (prev === value ? null : value));
@@ -60,7 +63,7 @@ export function DrawsPageClient({ initialFilter = null }: Props) {
   if (!draws) return null;
 
   const filteredDraws = activeFilter
-    ? draws.filter((item) => getDrawStatusFilter(item.status) === activeFilter)
+    ? draws.filter((item) => getDrawStatusFilter(item) === activeFilter)
     : draws;
 
   const items = filteredDraws.map(toDrawActivityItem);
@@ -88,7 +91,7 @@ export function DrawsPageClient({ initialFilter = null }: Props) {
           items={items}
           renderRightContent={(item) => {
             const draw = filteredDraws.find((d) => d.id === item.id)!;
-            const filter = getDrawStatusFilter(draw.status);
+            const filter = getDrawStatusFilter(draw);
 
             return filter === 'pendingResult' ? (
               <Box
@@ -100,7 +103,11 @@ export function DrawsPageClient({ initialFilter = null }: Props) {
                 disabled={isConfirming}
                 onClick={() =>
                   confirmResult(draw.id, {
-                    onSuccess: (result) => setModalResult(result),
+                    onSuccess: (payload) =>
+                      setModalResult({
+                        result: payload.result,
+                        winningRatePercent: payload.winningRatePercent,
+                      }),
                   })
                 }
               >
@@ -122,7 +129,7 @@ export function DrawsPageClient({ initialFilter = null }: Props) {
       {modalResult && (
         <DrawResultModal
           isOpen={!!modalResult}
-          result={modalResult}
+          result={modalResult.result}
           onClose={() => setModalResult(null)}
         />
       )}

--- a/src/app/(protected)/mypage/hooks/use-draw-history.ts
+++ b/src/app/(protected)/mypage/hooks/use-draw-history.ts
@@ -15,6 +15,10 @@ import {
   getDrawStatusTone,
 } from '@/app/(protected)/mypage/lib/draw-status';
 import type { DrawResult } from '@/app/(protected)/mypage/activity/draws/components/draw-result-modal';
+import type {
+  ConfirmDrawResultResponse,
+  DrawTicket,
+} from '@/types/draw/draw-confirm-result';
 import { snackbar } from '@/components/ui/snackbar';
 
 export function toDrawActivityItem(item: DrawHistoryItem): ActivityItem {
@@ -24,9 +28,9 @@ export function toDrawActivityItem(item: DrawHistoryItem): ActivityItem {
     image: item.vthumbnailUrl,
     price: formatWon(item.price),
     paidAt: item.paidAt ? formatDate(item.paidAt) : '-',
-    stateLabel: getDrawStatusLabel(item.status),
-    stateTone: getDrawStatusTone(item.status),
-    isResultPending: getDrawStatusFilter(item.status) === 'pendingResult',
+    stateLabel: getDrawStatusLabel(item),
+    stateTone: getDrawStatusTone(item),
+    isResultPending: getDrawStatusFilter(item) === 'pendingResult',
   };
 }
 
@@ -45,37 +49,63 @@ export function useDrawHistory() {
   });
 }
 
+export type ConfirmDrawResultPayload = {
+  result: DrawResult;
+  winningRatePercent: string | null;
+  ticket: DrawTicket | null;
+};
+
+const CONFIRM_RESULT_ERROR_MESSAGES: Record<string, string> = {
+  D006: '아직 결과 집계 중이에요.',
+  D007: '아직 결과 발표 전이에요.',
+  T003: '이미 티켓이 발급되었어요.',
+  D010: '응모 내역을 찾을 수 없어요.',
+};
+
 export function useConfirmDrawResult() {
   const queryClient = useQueryClient();
 
-  return useMutation<DrawResult, Error, number>({
-    mutationFn: async (entryId: number): Promise<DrawResult> => {
+  return useMutation<ConfirmDrawResultPayload, Error, number>({
+    mutationFn: async (entryId: number): Promise<ConfirmDrawResultPayload> => {
       const response = await authFetch(
         `/api/draws/entries/${entryId}/confirm-result`,
         { method: 'POST' }
       );
 
-      if (response.ok) return 'won';
+      const body =
+        (await response.json()) as ApiResponse<ConfirmDrawResultResponse | null>;
 
-      const result = (await response.json()) as ApiResponse<null>;
-      if (result.code === 'D008') return 'notWon';
-      if (result.code === 'D006') throw new Error('RESULT_NOT_READY');
+      if (response.ok && body.data) {
+        const { resultType, winningRatePercent, ticket } = body.data;
+        const result: DrawResult =
+          resultType === 'FAILED'
+            ? 'notWon'
+            : winningRatePercent
+              ? 'lucky'
+              : 'won';
+        return { result, winningRatePercent, ticket };
+      }
 
-      throw new Error(result.message ?? 'confirm-result failed');
+      throw new Error(body.code ?? body.message ?? 'CONFIRM_RESULT_FAILED');
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['history', 'draws'] });
     },
     onError: (error) => {
-      if (error.message === 'RESULT_NOT_READY') {
+      const description =
+        CONFIRM_RESULT_ERROR_MESSAGES[error.message] ??
+        '잠시 후 다시 시도해주세요.';
+      const isInformative = error.message in CONFIRM_RESULT_ERROR_MESSAGES;
+
+      if (isInformative) {
         snackbar.informative({
-          title: '아직 결과 집계 중이에요.',
-          description: '잠시 후 다시 확인해주세요.',
+          title: '결과를 확인할 수 없어요.',
+          description,
         });
         return;
       }
       snackbar.destructive({
-        title: '결과 확인에 실패했어요.',
+        title: '결과 확인에 실패했어요',
         description: '잠시 후 다시 시도해주세요.',
       });
     },

--- a/src/app/(protected)/mypage/lib/draw-status.ts
+++ b/src/app/(protected)/mypage/lib/draw-status.ts
@@ -1,4 +1,7 @@
-import type { ActivityStatusTone } from '@/app/(protected)/mypage/types';
+import type {
+  ActivityStatusTone,
+  DrawHistoryItem,
+} from '@/app/(protected)/mypage/types';
 
 export type DrawStatusFilter =
   | 'won'
@@ -28,20 +31,24 @@ const STATUS_TONE_MAP: Record<DrawStatusFilter, ActivityStatusTone> = {
   pendingResult: 'warning',
 };
 
-export function getDrawStatusFilter(
-  status: string | null | undefined
-): DrawStatusFilter {
-  const s = (status ?? '').trim().toUpperCase();
-  if (s === 'WON' || s === '당첨') return 'won';
-  if (s === 'LOST' || s === '미당첨') return 'notWon';
-  if (s === 'IN_PROGRESS' || s === '진행중') return 'inProgress';
-  return 'pendingResult';
+type DrawStatusInput = Pick<
+  DrawHistoryItem,
+  'status' | 'resultAvailable' | 'resultChecked' | 'clickable'
+>;
+
+export function getDrawStatusFilter(item: DrawStatusInput): DrawStatusFilter {
+  if (item.status === 'WINNER') return 'won';
+  if (item.status === 'FAILED') return 'notWon';
+  if (item.resultAvailable && !item.resultChecked && item.clickable) {
+    return 'pendingResult';
+  }
+  return 'inProgress';
 }
 
-export function getDrawStatusLabel(status: string): string {
-  return STATUS_LABEL_MAP[getDrawStatusFilter(status)];
+export function getDrawStatusLabel(item: DrawStatusInput): string {
+  return STATUS_LABEL_MAP[getDrawStatusFilter(item)];
 }
 
-export function getDrawStatusTone(status: string): ActivityStatusTone {
-  return STATUS_TONE_MAP[getDrawStatusFilter(status)];
+export function getDrawStatusTone(item: DrawStatusInput): ActivityStatusTone {
+  return STATUS_TONE_MAP[getDrawStatusFilter(item)];
 }

--- a/src/app/(protected)/mypage/types/index.ts
+++ b/src/app/(protected)/mypage/types/index.ts
@@ -14,6 +14,7 @@ export type ActivityItem = {
   drawResult?: 'lucky' | 'won' | 'notWon';
 };
 
+export type DrawHistoryStatus = 'APPLIED' | 'WINNER' | 'FAILED';
 export interface DrawHistoryItem {
   id: number;
   drawId: number;
@@ -22,7 +23,11 @@ export interface DrawHistoryItem {
   price: number;
   paidAt: string | null;
   displayStatus: string;
-  status: string;
+  status: DrawHistoryStatus;
+  announcementAt: string | null;
+  resultAvailable: boolean;
+  resultChecked: boolean;
+  clickable: boolean;
 }
 
 export interface BidHistoryItem {

--- a/src/types/draw/draw-confirm-result.ts
+++ b/src/types/draw/draw-confirm-result.ts
@@ -1,0 +1,25 @@
+export type DrawResultType = 'WINNER' | 'FAILED';
+
+export type DrawTicketStatus = 'ISSUED' | string;
+
+export type DrawTicketSourceType = 'DRAW' | string;
+
+export interface DrawTicket {
+  ticketId: number;
+  ticketNumber: string;
+  reservationNo: string | null;
+  status: DrawTicketStatus;
+  sourceType: DrawTicketSourceType;
+  sourceId: number;
+}
+
+export interface ConfirmDrawResultResponse {
+  drawEntryId: number;
+  drawId: number;
+  resultType: DrawResultType;
+  hasTicket: boolean;
+  announcementAt: string;
+  resultCheckedAt: string;
+  winningRatePercent: string | null;
+  ticket: DrawTicket | null;
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Related to #188 

이전 PR #188 의 리뷰 요구사항에 기재된 후속 작업입니다. 
(백엔드 user-service DTO 에 4개 필드가 추가된 후의 재작업)

## 📝 작업 내용

> 무엇을 변경했는지 간결하게 설명해주세요.

- [ ] DrawHistoryItem 타입에 누락 필드 추가 (announcementAt, resultAvailable, resultChecked, clickable)
- [ ] DrawHistoryItem.status 타입을 'APPLIED' | 'WINNER' | 'FAILED' 로 좁힘
- [ ] getDrawStatusFilter 를 status 문자열 추론에서 플래그 기반(resultAvailable/resultChecked/clickable) 로직으로 교체
- [ ] confirm-result 응답 풀 파싱: resultType, winningRatePercent, ticket 활용
- [ ] winningRatePercent 를 DrawResultModal 의 lucky 케이스에 동적 주입 (하드코딩 "상위 13%" 제거)
- [ ] 에러 코드 매핑 확장: D006(집계중), D007(발표 전), T003(이미 발급), D010(미존재) — 기존 D008 제거
- [ ] ConfirmDrawResultResponse / DrawTicket 타입 신규 정의 (src/types/draw/draw-confirm-result.ts)

## 💡 작업 목적

> 왜 이 작업이 필요한지 기술적 이유나 협업 관점의 목적을 설명해주세요.

- 당시 백엔드 DTO 누락으로 clickable 대신 status 추론으로 버튼 노출을 우회 처리했던 부분을, 
백엔드 픽스 반영하여 명세 기반으로 정상화
- winningRatePercent (예: "3%", "<1%") 를 모달에 노출 (하드코딩 "상위 13%" 제거)
-  미당첨이 더 이상 에러 코드(D008)가 아닌 정상 응답(resultType: "FAILED")으로 내려오도록 함

## 🧪 테스트 결과

> 변경 사항에 대한 테스트 방법 및 결과를 기술해주세요.

(운영에서 테스트 필요)
- [ ] resultAvailable=false → 배지 노출 (진행중), 버튼 비노출
- [ ] resultAvailable=true && resultChecked=false && clickable=true → "결과 확인하기" 버튼 노출
- [ ] WINNER + winningRatePercent 非 null → lucky 모달 + 실제 % 문구
- [ ] WINNER + winningRatePercent null → won 모달
- [ ] FAILED → notWon 모달
- [ ] D006/D007 → informative 스낵바, T003/D010/기타 → destructive 스낵바