### PR TITLE
fix: vThumbnailUrl → thumbnailUrl 로 변경 (백엔드 필드 변경으로)

### DIFF
--- a/src/app/(protected)/mypage/hooks/use-draw-history.ts
+++ b/src/app/(protected)/mypage/hooks/use-draw-history.ts
@@ -25,7 +25,7 @@ export function toDrawActivityItem(item: DrawHistoryItem): ActivityItem {
   return {
     id: item.id,
     title: item.title,
-    image: item.vthumbnailUrl,
+    image: item.thumbnailUrl,
     price: formatWon(item.price),
     paidAt: item.paidAt ? formatDate(item.paidAt) : '-',
     stateLabel: getDrawStatusLabel(item),

--- a/src/app/(protected)/mypage/types/index.ts
+++ b/src/app/(protected)/mypage/types/index.ts
@@ -18,7 +18,7 @@ export type DrawHistoryStatus = 'APPLIED' | 'WINNER' | 'FAILED';
 export interface DrawHistoryItem {
   id: number;
   drawId: number;
-  vthumbnailUrl: string | null;
+  thumbnailUrl: string | null;
   title: string;
   price: number;
   paidAt: string | null;

--- a/src/components/sale-detail/info/draw-entry-success-modal.tsx
+++ b/src/components/sale-detail/info/draw-entry-success-modal.tsx
@@ -47,7 +47,7 @@ export default function DrawEntrySuccessModal({
           <div className="flex gap-[16px] border-b border-[var(--line-3)] pb-ms">
             <div className="relative w-[62px] aspect-[3/4] rounded-s border overflow-hidden">
               <Image
-                src={data.vThumbnailUrl}
+                src={data.thumbnailUrl}
                 alt={data.popupTitle}
                 fill
                 className="object-cover"

--- a/src/types/draw/draw-apply.ts
+++ b/src/types/draw/draw-apply.ts
@@ -11,7 +11,7 @@ export type DrawEntryValidationErrorData = {
 };
 
 export type DrawEntrySuccessData = {
-  vThumbnailUrl: string;
+  thumbnailUrl: string;
   popupTitle: string;
   popupAddress: string;
   entryDate: string;


### PR DESCRIPTION
GET /history/draws (user-service)
vThumbnailUrl → thumbnailUrl

POST /draws/{drawId}/options/{optionId}/entries (draw-service, 응모 신청 결과)
vThumbnailUrl → thumbnailUrl

백엔드 응답 필드 변경으로 인한 수정