### PR TITLE
fix: 백엔드 displayStatus 값 받도록 수정

### DIFF
--- a/src/app/(protected)/mypage/hooks/use-draw-history.ts
+++ b/src/app/(protected)/mypage/hooks/use-draw-history.ts
@@ -11,7 +11,6 @@ import type {
 } from '@/app/(protected)/mypage/types';
 import {
   getDrawStatusFilter,
-  getDrawStatusLabel,
   getDrawStatusTone,
 } from '@/app/(protected)/mypage/lib/draw-status';
 import type { DrawResult } from '@/app/(protected)/mypage/activity/draws/components/draw-result-modal';
@@ -28,7 +27,7 @@ export function toDrawActivityItem(item: DrawHistoryItem): ActivityItem {
     image: item.thumbnailUrl,
     price: formatWon(item.price),
     paidAt: item.paidAt ? formatDate(item.paidAt) : '-',
-    stateLabel: getDrawStatusLabel(item),
+    stateLabel: item.displayStatus,
     stateTone: getDrawStatusTone(item),
     isResultPending: getDrawStatusFilter(item) === 'pendingResult',
   };


### PR DESCRIPTION
백엔드 history/draws의 displayStatus 값을 받도록 수정