### PR TITLE
feat: 슈퍼 계정(시연용) 게스트 로그인 추가

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -46,7 +46,13 @@ type SocialProvider = 'kakao' | 'naver';
 const REDIRECT_DELAY = 1000;
 
 const isValidRedirectPath = (value: string | null): value is string => {
-  return typeof value === 'string' && value.startsWith('/');
+  return (
+    typeof value === 'string' &&
+    value.startsWith('/') &&
+    // 프로토콜 상대 URL(//evil.com) 및 백슬래시 기반 외부 리다이렉트 방지
+    !value.startsWith('//') &&
+    !value.includes('\\')
+  );
 };
 
 export default function Login() {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 // 로그인
 'use client';
+import { getBillingList } from '@/app/api/payment/get-billing-list';
 import { getServiceBaseUrl } from '@/app/api/shared/route-helpers';
 import { Icon } from '@/components/Icon/Icon';
 import { Wrapper } from '@/components/layout/wrapper';
@@ -11,9 +12,14 @@ import {
   AUTH_ERROR_CODES,
   AUTH_MESSAGES,
   LOGIN_REDIRECT_KEY,
+  SNACKBAR_KEY,
+  SNACKBAR_MESSAGES,
+  SUPER_ACCESS_TOKEN_KEY,
 } from '@/constants/auth';
 import { RADIUS } from '@/constants/design-system';
 import { useLoginCollector } from '@/features/anti-macro';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import { SuperLoginResponse } from '@/types/auth/auth';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -39,12 +45,22 @@ const ERROR_MESSAGE_MAP: Record<string, string> = {
 type SocialProvider = 'kakao' | 'naver';
 const REDIRECT_DELAY = 1000;
 
+const isValidRedirectPath = (value: string | null): value is string => {
+  return typeof value === 'string' && value.startsWith('/');
+};
+
 export default function Login() {
   const router = useRouter();
   const params = useSearchParams();
   const errorCode = params.get('error');
   const redirect = params.get('redirect');
+  const isSuperuserMode = params.get('superuser') === 'true';
   const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const clearAccessToken = useAuthStore((state) => state.clearAccessToken);
+  const setPaymentRegistered = useAuthStore(
+    (state) => state.setPaymentRegistered
+  );
   const {
     submitSignals,
     honeypotProps,
@@ -70,10 +86,68 @@ export default function Login() {
     window.location.href = `${API_BASE_URL}/auth/oauth/${provider}`;
   };
 
+  const guestLoginHandler = async () => {
+    if (isLoggingIn) return;
+    setIsLoggingIn(true);
+
+    try {
+      const response = await fetch('/api/users/login/super', {
+        method: 'POST',
+        cache: 'no-store',
+      });
+      const result: SuperLoginResponse = await response.json();
+
+      if (!response.ok || !result.data?.accessToken) {
+        const code = result.code ?? 'S001';
+        clearAccessToken();
+        sessionStorage.setItem(
+          SNACKBAR_KEY,
+          JSON.stringify(SNACKBAR_MESSAGES.LOGIN_FAIL)
+        );
+        router.replace(`/login?superuser=true&error=${code}`);
+        return;
+      }
+
+      const { accessToken } = result.data;
+      sessionStorage.setItem(SUPER_ACCESS_TOKEN_KEY, accessToken);
+      setAccessToken(accessToken);
+      sessionStorage.setItem(
+        SNACKBAR_KEY,
+        JSON.stringify(SNACKBAR_MESSAGES.LOGIN_SUCCESS)
+      );
+
+      try {
+        const billingList = await getBillingList(accessToken);
+        setPaymentRegistered(billingList.length > 0);
+      } catch (error: unknown) {
+        console.error('[billing] error:', error);
+        setPaymentRegistered(null);
+      }
+
+      const savedRedirect = sessionStorage.getItem(LOGIN_REDIRECT_KEY);
+      sessionStorage.removeItem(LOGIN_REDIRECT_KEY);
+
+      if (isValidRedirectPath(savedRedirect)) {
+        router.replace(savedRedirect);
+        return;
+      }
+
+      router.replace('/');
+    } catch (error) {
+      console.error('[guest-login] failed:', error);
+      setIsLoggingIn(false);
+      sessionStorage.setItem(
+        SNACKBAR_KEY,
+        JSON.stringify(SNACKBAR_MESSAGES.NETWORK_ERROR)
+      );
+      router.replace('/login?superuser=true&error=S001');
+    }
+  };
+
   const toLogin = useCallback(() => {
     setIsLoggingIn(false);
-    router.replace('/login');
-  }, [router]);
+    router.replace(isSuperuserMode ? '/login?superuser=true' : '/login');
+  }, [router, isSuperuserMode]);
 
   useEffect(() => {
     if (!redirect) return;
@@ -112,38 +186,58 @@ export default function Login() {
       </div>
 
       <div className="btn-group w-full max-w-[360px] mx-auto flex flex-col gap-3 pt-ml">
-        <Button
-          size="large"
-          className={`w-full bg-[#FEE500] hover:bg-[#FEE500] active:bg-[#FEE500] disabled:bg-[#FEE500] disabled:text-[var(--content-high)] ${RADIUS.MS}`}
-          leftIcon={
-            <Icon
-              name="LogoKakao"
-              size={24}
-              className="text-[var(--content-high)]"
-            ></Icon>
-          }
-          disabled={isLoggingIn}
-          onClick={() => socialLoginHandler('kakao')}
-        >
-          <Typography
-            variant="label-1"
-            weight="medium"
-            className="text-[var(--content-high)]"
+        {isSuperuserMode ? (
+          <Button
+            size="large"
+            variant="primary"
+            className={`w-full ${RADIUS.MS}`}
+            disabled={isLoggingIn}
+            onClick={guestLoginHandler}
           >
-            카카오 로그인
-          </Typography>
-        </Button>
-        <Button
-          size="large"
-          className={`w-full bg-[#03C75A] hover:bg-[#03C75A] active:bg-[#03C75A] disabled:bg-[#03C75A] disabled:text-white ${RADIUS.MS}`}
-          leftIcon={<Icon name="LogoNaver" size={24}></Icon>}
-          onClick={() => socialLoginHandler('naver')}
-          disabled={isLoggingIn}
-        >
-          <Typography variant="label-1" weight="medium">
-            네이버 로그인
-          </Typography>
-        </Button>
+            <Typography
+              variant="label-1"
+              weight="medium"
+              className="text-white"
+            >
+              게스트 로그인
+            </Typography>
+          </Button>
+        ) : (
+          <>
+            <Button
+              size="large"
+              className={`w-full bg-[#FEE500] hover:bg-[#FEE500] active:bg-[#FEE500] disabled:bg-[#FEE500] disabled:text-[var(--content-high)] ${RADIUS.MS}`}
+              leftIcon={
+                <Icon
+                  name="LogoKakao"
+                  size={24}
+                  className="text-[var(--content-high)]"
+                ></Icon>
+              }
+              disabled={isLoggingIn}
+              onClick={() => socialLoginHandler('kakao')}
+            >
+              <Typography
+                variant="label-1"
+                weight="medium"
+                className="text-[var(--content-high)]"
+              >
+                카카오 로그인
+              </Typography>
+            </Button>
+            <Button
+              size="large"
+              className={`w-full bg-[#03C75A] hover:bg-[#03C75A] active:bg-[#03C75A] disabled:bg-[#03C75A] disabled:text-white ${RADIUS.MS}`}
+              leftIcon={<Icon name="LogoNaver" size={24}></Icon>}
+              onClick={() => socialLoginHandler('naver')}
+              disabled={isLoggingIn}
+            >
+              <Typography variant="label-1" weight="medium">
+                네이버 로그인
+              </Typography>
+            </Button>
+          </>
+        )}
       </div>
     </Wrapper>
   );

--- a/src/app/api/users/login/super/route.ts
+++ b/src/app/api/users/login/super/route.ts
@@ -1,0 +1,26 @@
+import {
+  createServerErrorResponse,
+  getServiceBaseUrl,
+  handleProxyResponse,
+} from '@/app/api/shared/route-helpers';
+
+const API_BASE_URL = getServiceBaseUrl('user');
+
+export async function POST() {
+  if (!API_BASE_URL) {
+    return createServerErrorResponse();
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/users/login/super`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      cache: 'no-store',
+    });
+
+    return handleProxyResponse(response, { withCookies: true });
+  } catch (error) {
+    console.error('[users/login/super]', error);
+    return createServerErrorResponse();
+  }
+}

--- a/src/components/auth/auth-session-restore.tsx
+++ b/src/components/auth/auth-session-restore.tsx
@@ -45,6 +45,15 @@ export default function AuthSessionRestore({
         : null;
     if (superToken) {
       setAccessToken(superToken);
+      void (async () => {
+        try {
+          const billingList = await getBillingList(superToken);
+          setPaymentRegistered(billingList.length > 0);
+        } catch (error: unknown) {
+          console.error('[billing] error:', error);
+          setPaymentRegistered(null);
+        }
+      })();
       return;
     }
 

--- a/src/components/auth/auth-session-restore.tsx
+++ b/src/components/auth/auth-session-restore.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { getBillingList } from '@/app/api/payment/get-billing-list';
+import { SUPER_ACCESS_TOKEN_KEY } from '@/constants/auth';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { useEffect, useRef } from 'react';
 
-export default function AuthSessionRestore() {
+export default function AuthSessionRestore({
+  isLoggedIn,
+}: {
+  isLoggedIn: boolean;
+}) {
   const requestedRef = useRef(false);
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const clearAccessToken = useAuthStore((state) => state.clearAccessToken);
@@ -31,6 +36,22 @@ export default function AuthSessionRestore() {
         setAccessToken(devToken);
         return;
       }
+    }
+
+    // 슈퍼(시연) 계정 세션: sessionStorage에 저장된 accessToken 복구
+    const superToken =
+      typeof window !== 'undefined'
+        ? window.sessionStorage.getItem(SUPER_ACCESS_TOKEN_KEY)
+        : null;
+    if (superToken) {
+      setAccessToken(superToken);
+      return;
+    }
+
+    // refresh_token 쿠키 부재 시 refresh 호출 스킵
+    if (!isLoggedIn) {
+      clearAccessToken();
+      return;
     }
 
     const restoreSession = async () => {
@@ -87,7 +108,13 @@ export default function AuthSessionRestore() {
     };
 
     void restoreSession();
-  }, [setAccessToken, clearAccessToken, setAuthLoading, setPaymentRegistered]);
+  }, [
+    isLoggedIn,
+    setAccessToken,
+    clearAccessToken,
+    setAuthLoading,
+    setPaymentRegistered,
+  ]);
 
   return null;
 }

--- a/src/components/auth/conditional-auth-session-restore.tsx
+++ b/src/components/auth/conditional-auth-session-restore.tsx
@@ -1,19 +1,9 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { useEffect } from 'react';
-import { useAuthStore } from '@/features/auth/stores/auth-store';
 import AuthSessionRestore from './auth-session-restore';
 
 const AUTH_PATHS = ['/signup', '/verify', '/callback'];
-
-function SetUnauthenticated() {
-  const clearAccessToken = useAuthStore((state) => state.clearAccessToken);
-  useEffect(() => {
-    clearAccessToken();
-  }, [clearAccessToken]);
-  return null;
-}
 
 export default function ConditionalAuthSessionRestore({
   isLoggedIn,
@@ -21,13 +11,10 @@ export default function ConditionalAuthSessionRestore({
   isLoggedIn: boolean;
 }) {
   const pathname = usePathname();
-  const authStatus = useAuthStore((state) => state.authStatus);
 
   const isAuthPage = AUTH_PATHS.some((path) => pathname.startsWith(path));
 
   if (isAuthPage) return null;
-  if (!isLoggedIn && authStatus !== 'authenticated')
-    return <SetUnauthenticated />;
 
-  return <AuthSessionRestore />;
+  return <AuthSessionRestore isLoggedIn={isLoggedIn} />;
 }

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -123,6 +123,8 @@ export const TERMS: readonly {
 
 export const LOGIN_REDIRECT_KEY = 'loginRedirectPath';
 export const SNACKBAR_KEY = 'login_snackbar';
+// 슈퍼(시연) 계정 세션 — refresh_token 쿠키가 없어 탭 세션 동안만 유지
+export const SUPER_ACCESS_TOKEN_KEY = '__super_access_token';
 
 export const SNACKBAR_MESSAGES = {
   LOGIN_SUCCESS: {

--- a/src/features/auth/stores/auth-store.ts
+++ b/src/features/auth/stores/auth-store.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { SUPER_ACCESS_TOKEN_KEY } from '@/constants/auth';
 import { create } from 'zustand';
 
 export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
@@ -41,13 +42,17 @@ export const useAuthStore = create<AuthState>()((set) => ({
       authStatus: 'authenticated',
     }),
 
-  clearAccessToken: () =>
+  clearAccessToken: () => {
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.removeItem(SUPER_ACCESS_TOKEN_KEY);
+    }
     set({
       accessToken: null,
       authStatus: 'unauthenticated',
       isPaymentRegistered: null,
       billingCards: [],
-    }),
+    });
+  },
 
   setAuthLoading: () =>
     set({

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -6,3 +6,13 @@ export interface RefreshTokenResponse {
     expiresIn: number;
   } | null;
 }
+
+export interface SuperLoginResponse {
+  code: string;
+  message: string;
+  data: {
+    userId: number;
+    accessToken: string;
+    expiresIn: number;
+  } | null;
+}


### PR DESCRIPTION
## Summary
- `/login?superuser=true` 진입 시 카카오/네이버 버튼 대신 **게스트 로그인** 버튼만 노출
- `POST /users/login/super` 프록시 라우트(`/api/users/login/super`) 신설
- refresh_token 쿠키가 없는 슈퍼 계정을 위해 `sessionStorage(__super_access_token)` 기반 탭 세션 유지
- `AuthSessionRestore`에서 sessionStorage 슈퍼 토큰 우선 복구, 쿠키 부재 시 refresh 호출 스킵
- `clearAccessToken`에서 sessionStorage도 함께 정리 (로그아웃/401 경로 일원화)

## 참고
- API 명세의 "토큰 필요 여부 O"는 Request/Headers가 비어있어 오기로 판단, 무토큰으로 호출
- sessionStorage라 새 탭/탭 종료 시 세션 소멸 (시연용 의도)

## Test plan
- [ ] `/login` — 기존 카카오/네이버 버튼 정상 노출
- [ ] `/login?superuser=true` — 게스트 로그인 버튼만 노출
- [ ] 게스트 로그인 클릭 → 홈으로 이동, 로그인 성공 스낵바 표시
- [ ] 로그인 후 새로고침 → 세션 유지 (sessionStorage 복구)
- [ ] 로그아웃 → sessionStorage 정리, 로그인 페이지 복귀
- [ ] 탭 닫고 재접속 → 로그아웃 상태
- [ ] `redirect` 쿼리파라미터 포함 시 로그인 후 해당 경로로 이동
- [ ] 기존 OAuth 로그인 흐름(카카오/네이버) 리그레션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)