### PR TITLE
chore: 슈퍼 로그인 디버깅 console 제거

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -125,8 +125,7 @@ export default function Login() {
       try {
         const billingList = await getBillingList(accessToken);
         setPaymentRegistered(billingList.length > 0);
-      } catch (error: unknown) {
-        console.error('[billing] error:', error);
+      } catch {
         setPaymentRegistered(null);
       }
 

--- a/src/components/auth/auth-session-restore.tsx
+++ b/src/components/auth/auth-session-restore.tsx
@@ -49,8 +49,7 @@ export default function AuthSessionRestore({
         try {
           const billingList = await getBillingList(superToken);
           setPaymentRegistered(billingList.length > 0);
-        } catch (error: unknown) {
-          console.error('[billing] error:', error);
+        } catch {
           setPaymentRegistered(null);
         }
       })();


### PR DESCRIPTION
## Summary
- 시연용 슈퍼 계정은 billing 정보가 없는 경우가 많아 조회 실패가 일상적 → 두 곳의 billing 오류 로그 제거
- 네트워크 unhandled catch(`/api/users/login/super`, guest login fetch) 로그는 진단용으로 유지

## Changes
- `src/app/(auth)/login/page.tsx` — guestLoginHandler의 billing catch에서 `console.error` 제거
- `src/components/auth/auth-session-restore.tsx` — 슈퍼 세션 복구 branch의 billing catch에서 `console.error` 제거

## Test plan
- [ ] `/login?superuser=true` → 게스트 로그인 → 콘솔에 `[billing] error:` 미출력
- [ ] 로그인 후 새로고침 → 세션 복구 시에도 콘솔에 `[billing] error:` 미출력
- [ ] 일반 OAuth 로그인(카카오/네이버) 리그레션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)